### PR TITLE
FDS Validation: Add NRCC_Smoke_Tower to list of all validation cases.

### DIFF
--- a/Validation/Process_All_Output.sh
+++ b/Validation/Process_All_Output.sh
@@ -41,6 +41,7 @@ $VDIR/NIST_NRC/FDS_Output_Files/Process_Output.csh
 $VDIR/NIST_RSE_1994/FDS_Output_Files/Process_Output.csh
 $VDIR/NIST_Smoke_Alarms/FDS_Output_Files/Process_Output.csh
 $VDIR/NRCC_Facade/FDS_Output_Files/Process_Output.csh
+$VDIR/NRCC_Smoke_Tower/FDS_Output_Files/Process_Output.csh
 $VDIR/NRL_HAI/FDS_Output_Files/Process_Output.csh
 $VDIR/Pool_Fires/FDS_Output_Files/Process_Output.csh
 $VDIR/PRISME/FDS_Output_Files/Process_Output.csh


### PR DESCRIPTION
Glenn -- I needed to add NRCC_Smoke_Tower to this file, which serves as the master list of all validation cases.
