### PR TITLE
tkorhon1: main.f90 common DT change, now works for evacuation also.

### DIFF
--- a/FDS_Source/main.f90
+++ b/FDS_Source/main.f90
@@ -402,7 +402,10 @@ CALL WRITE_STRINGS
 
 ! Check for evacuation initialization stop
 
-IF (ANY(EVACUATION_ONLY)) CALL STOP_CHECK(1)
+IF (ANY(EVACUATION_ONLY)) THEN
+   CALL STOP_CHECK(1)
+   IF (.NOT.RESTART) ICYC = -EVAC_TIME_ITERATIONS
+END IF
 
 ! Sprinkler piping calculation
 
@@ -2800,8 +2803,7 @@ INTEGER :: NM,DISP
 
 TNOW = SECOND()
 
-!need to fix following line to make sure RETURN's only occur for evac cases (issue 2965)
-!IF (ICYC>-EVAC_TIME_ITERATIONS .AND. ICYC < 1) RETURN ! No dumps at the evacuation initialization phase
+IF (ANY(EVACUATION_ONLY) .AND. (ICYC<1 .AND. T>T_BEGIN)) RETURN ! No dumps at the evacuation initialization phase
 
 ! Dump out HRR info  after first "gathering" data to node 0
 


### PR DESCRIPTION
Now there is always evacuation_only check, so nothing is changed
for a plain fire mesh(es) calculation.

Next is new
< IF (ANY(EVACUATION_ONLY)) THEN
<    CALL STOP_CHECK(1)
<    IF (.NOT.RESTART) ICYC = -EVAC_TIME_ITERATIONS
< END IF

Next is old:

> IF (ANY(EVACUATION_ONLY)) CALL STOP_CHECK(1)

Above should not mesh any plain fire calculation.

Next is new
< IF (ANY(EVACUATION_ONLY) .AND. (ICYC<1 .AND. T>T_BEGIN)) RETURN ! No dumps at the evacuation initialization phase

Next is old

> !need to fix following line to make sure RETURN's only occur for evac cases (issue 2965)
> !IF (ICYC>-EVAC_TIME_ITERATIONS .AND. ICYC < 1) RETURN ! No dumps at the evacuation initialization phase

This should not mess any fire only calculation.
