### PR TITLE
tkorhon1: FDS Source, evacuation time change in EVAC_MAIN_LOOP.

### DIFF
--- a/FDS_Source/evac.f90
+++ b/FDS_Source/evac.f90
@@ -1950,7 +1950,6 @@ CONTAINS
             CASE Default
                CONTINUE
             END SELECT
-            DIA_MEAN = 0.51_EB
          END IF
 
          !
@@ -8295,7 +8294,7 @@ CONTAINS
              FAC_V0_DOWN = ESS%FAC_V0_DOWN
              FAC_V0_HORI = ESS%FAC_V0_HORI
              IF (EVAC_PERSON_CLASSES(HR%IPC)%FAC_V0_HORI >= TWO_EPSILON_EB) THEN
-                FAC_V0_HORI = EVAC_PERSON_CLASSES(HR%IPC)%FAC_V0_UP
+                FAC_V0_HORI = EVAC_PERSON_CLASSES(HR%IPC)%FAC_V0_HORI
              END IF
              IF (EVAC_PERSON_CLASSES(HR%IPC)%FAC_V0_UP >= TWO_EPSILON_EB) THEN
                 IF ((ESS%H - ESS%H0) <= -TWO_EPSILON_EB) THEN

--- a/FDS_Source/main.f90
+++ b/FDS_Source/main.f90
@@ -3127,6 +3127,7 @@ IF (ICYC < 1) DT = EVAC_DT
 IF (ICYC < 1) DT_NEW = DT_EVAC
 IF (ICYC == 1) DT = DT_EVAC ! Initial fire dt that was read in
 IF (ICYC == 1) T  = T_BEGIN ! Initial fire t  that was read in
+IF (ICYC == 1) T_EVAC = T_BEGIN - 0.1_EB*MIN(EVAC_DT_FLOWFIELD,EVAC_DT_STEADY_STATE)
 IF (ICYC > 0) T_FIRE  = T
 IF (ICYC > 0) EVAC_DT = DT
 


### PR DESCRIPTION
Added line in EVAC_MAIN_LOOP so that at ICYC=1 T_EVAC is a little bit
less than T_FIRE. This way the EVAC_EFF file is written at ICYC=1.
This used to be the case before (when each fire mesh nad differend DT).
This was broken in the process, where same T and DT was made for all
fire meshes. A small EVSS related bug is also fixed (PERS line given fac_v0_hori).
Also dia_mean value is correct for distributions, where it is not input value (not
needed to specify the random distributrion). Dia_mean is used to calculate
the moment of inerria, so this bug did not matter much. And it did not matter
for the pre-defined person classes (dia_mean was set in the program source).
