### PR TITLE
FDS Source: Add write statement to prevent optimization of an initial…

### DIFF
--- a/FDS_Source/radi.f90
+++ b/FDS_Source/radi.f90
@@ -80,6 +80,7 @@ DO I=1,NRT
          DLY(N) =  (-SIN(DPHI0/2.)*(SIN(PHIUP)-SIN(PHILOW))  +COS(DPHI0/2.)*(COS(PHILOW)-COS(PHIUP)))*F_THETA
          DLB(N) =  (-SIN(DPHI0/2.)*(SIN(PHIUP)-SIN(PHILOW))  -COS(DPHI0/2.)*(COS(PHILOW)-COS(PHIUP)))*F_THETA
          DLZ(N)    = 0.5_EB*(PHIUP-PHILOW)   * ((SIN(THETAUP))**2-(SIN(THETALOW))**2)
+         IF (N==1000000) WRITE(LU_ERR,'(A)') 'This line should never get executed. It is here only to prevent optimization.'
       ELSEIF (TWO_D) THEN
          DLX(N) = (SIN(PHIUP)-SIN(PHILOW))*F_THETA
          DLY(N) = 0._EB


### PR DESCRIPTION
This is a bit of a hack. In cylindrical coordinates, the calculation of the radiation solid angles is slightly different due to optimization (-O2) of the routine. The angles DLY(1), DLY(11), DLY(21), etc., are very close to zero, but positive with -O1 or less optimization. They are slightly negative with -O2. The calculation is sensitive to positive and negative angles. The verification case plate_view_factor_cyl_100.fds is different by about 10 kW/m2 depending on the optimization level. The write statement added in this commit suppresses the optimization, and the same result is obtained at all levels of optimization. I could not figure out how exactly the optimization changed the calculation, so I'm just going to suppress it for now. 
