### PR TITLE
smv build: Add mingw/msys as a build target for smokeview.

### DIFF
--- a/SMV/Build/LIBS/lib_win_mingw_64/makelibs.sh
+++ b/SMV/Build/LIBS/lib_win_mingw_64/makelibs.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+OPTS="-g -6"
+LIBDIR=`pwd`
+SRCDIR=$LIBDIR/../../../source
+cd $SRCDIR
+SRCDIR=`pwd`
+
+# GD
+cd $SRCDIR/gd-2.0.15
+./makelib.sh $OPTS
+cp libgd.a $LIBDIR/.
+
+# GLUI
+cd $SRCDIR/glui_v2_1_beta
+./makelib.sh $OPTS
+cp libglui.a $LIBDIR/.
+
+# GLUT
+cd $SRCDIR/glut-3.7.6
+export TARGET=libglutwin.a
+./makelib.sh $OPTS
+cp libglutwin.a "$LIBDIR"/.
+
+# JPEG
+cd $SRCDIR/jpeg-6b
+./makelib.sh $OPTS
+cp libjpeg.a $LIBDIR/.
+
+# PNG
+cd $SRCDIR/png125
+./makelib.sh $OPTS
+cp libpng.a $LIBDIR/.
+
+# ZLIB
+cd $SRCDIR/zlib114
+./makelib.sh $OPTS
+cp libz.a $LIBDIR/.

--- a/SMV/Build/Makefile
+++ b/SMV/Build/Makefile
@@ -4,9 +4,9 @@
 #To use this Makefile cd to a sub-directory and type make_smv.sh or make_smv.bat
 
 SOURCE_DIR = ../../source/
-SMV_TESTFLAG = 
+SMV_TESTFLAG =
 SMV_TESTSTRING =
-SMV_PROFILEFLAG = 
+SMV_PROFILEFLAG =
 SMV_PROFILESTRING =
 ifeq ($(shell echo "check_quotes"),"check_quotes")
   GIT_HASH := $(shell ..\..\..\Utilities\Scripts\githash)
@@ -97,7 +97,7 @@ SMV_LIBS_64 = $(WIN_LIBDIR_64)\glui.lib $(WIN_LIBDIR_64)\glut32.lib $(WIN_LIBDIR
 ms_win_64 : INC = -I ../../source/include -I ../../source/shared -I ../../source/smokeview -I ../../source/glew
 ms_win_64 : FFLAGS    = -O2 /iface:stdref /fpp
 ms_win_64 : CFLAGS    = -O1 -D WIN32 -D _CONSOLE -D X64 -D GLEW_STATIC -D PTW32_STATIC_LIB $(SMV_TESTFLAG)
-ms_win_64 : LFLAGS    = /F32768000 
+ms_win_64 : LFLAGS    = /F32768000
 ms_win_64 : CC        = cl
 ms_win_64 : CPP       = cl
 ms_win_64 : FC        = ifort
@@ -126,9 +126,9 @@ intel_win_64_db : $(objwin)
 # ------------- intel_win_64 ----------------
 
 intel_win_64 : INC = -I ../../source/include -I ../../source/shared -I ../../source/smokeview -I ../../source/glew
-intel_win_64 : FFLAGS    = -O2 /iface:stdref /fpp -D WIN32 /fpscomp:general 
+intel_win_64 : FFLAGS    = -O2 /iface:stdref /fpp -D WIN32 /fpscomp:general
 intel_win_64 : CFLAGS    = -O1 -D WIN32 -D pp_INTEL -D _CONSOLE -D X64 -D GLEW_STATIC -D PTW32_STATIC_LIB $(SMV_TESTFLAG) $(GITINFO)
-intel_win_64 : LFLAGS    = /F32768000 
+intel_win_64 : LFLAGS    = /F32768000
 intel_win_64 : CC        = icl
 intel_win_64 : CPP       = icl
 intel_win_64 : FC        = ifort
@@ -150,7 +150,7 @@ LINUX_INTEL_LIBS_64 = $(IFORT_COMPILER_LIB)/intel64/libifcore.a  $(IFORT_COMPILE
 intel_linux_64 : FFLAGS    = -O0 -traceback -m64 -static-intel -fpp -D pp_noappend
 intel_linux_64 : CFLAGS    = -O0 -traceback -m64 -static-intel -D pp_LINUX -D pp_INTEL $(SMV_TESTFLAG) $(SMV_PROFILEFLAG) $(GITINFO)
 intel_linux_64 : LFLAGS    = -m64 -static-intel
-intel_linux_64 : CC        = icc 
+intel_linux_64 : CC        = icc
 intel_linux_64 : CPP       = icpc
 intel_linux_64 : FC        = ifort
 intel_linux_64 : exe       = smokeview_linux_$(SMV_TESTSTRING)64$(SMV_PROFILESTRING)
@@ -177,7 +177,7 @@ intel_linux_64_db : $(obj)
 intel_linux_64_profile : FFLAGS    = -O0 -m64 -static-intel -fpp -D pp_noappend -p
 intel_linux_64_profile : CFLAGS    = -O0 -m64 -static-intel -D pp_LINUX -D pp_INTEL -p $(GITINFO)
 intel_linux_64_profile : LFLAGS    = -m64 -static-intel
-intel_linux_64_profile : CC        = icc 
+intel_linux_64_profile : CC        = icc
 intel_linux_64_profile : CPP       = icpc
 intel_linux_64_profile : FC        = ifort
 intel_linux_64_profile : exe       = smokeview_linux_64p
@@ -211,6 +211,27 @@ gnu_linux_64 : exe       = smokeview_linux_$(SMV_TESTSTRING)64
 gnu_linux_64 : $(obj)
 	$(CPP) -o $(bin)/$(exe) $(obj) $(LFLAGS) -L $(LIB_DIR)/lib_linux_gnu_64 $(FULL_SMV_LIBS) -lgfortran $(LINUX_SYSTEMLIBS)
 
+# ------------- mingw_win_64 ----------------
+
+MINGWIN_LIBDIR_64 = $(LIB_DIR)/lib_win_mingw_64
+MINGSMV_LIBS_64 = $(MINGWIN_LIBDIR_64)/libglui.a $(MINGWIN_LIBDIR_64)/libgd.a \
+	$(MINGWIN_LIBDIR_64)/libjpeg.a $(MINGWIN_LIBDIR_64)/libpng.a \
+	$(MINGWIN_LIBDIR_64)/libz.a $(MINGWIN_LIBDIR_64)/libglutwin.a
+
+mingw_win_64 : FFLAGS    = -O0 -m64 -x f95-cpp-input -D pp_GCC -D pp_noappend \
+						       -ffree-form -frecord-marker=4 -fno-underscoring
+mingw_win_64 : CFLAGS    = -O0 -m64 -D pp_LINUX -D GLEW_STATIC
+mingw_win_64 : LFLAGS    = -m64
+mingw_win_64 : CC        = gcc
+mingw_win_64 : CPP       = g++
+mingw_win_64 : FC        = gfortran
+mingw_win_64 : exe       = smokeview_mingw_$(SMV_TESTSTRING)64
+
+mingw_win_64 : $(obj)
+	$(CPP) -o $(bin)/$(exe) $(obj) $(LFLAGS) -L $(MINGWIN_LIBDIR_64) \
+		$(MINGSMV_LIBS_64) -lgfortran -lm -lopengl32 -lglu32 \
+		-lgdi32 -lwinmm -lcomdlg32 -lpthread
+
 # VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
 # VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV   OSX   VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
 # VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
@@ -222,7 +243,7 @@ OSX_INTEL_LIBS = $(IFORT_COMPILER_LIB)/libifcoremt.a $(IFORT_COMPILER_LIB)/libim
 intel_osx_64 : FFLAGS    = -O0 -m64 -static-intel -fpp -D pp_OSX -mmacosx-version-min=10.4
 intel_osx_64 : CFLAGS    = -O0 -m64 -static-intel -D pp_OSX  -D pp_INTEL -mmacosx-version-min=10.4 $(SMV_TESTFLAG) $(SMV_PROFILEFLAG) $(GITINFO)
 intel_osx_64 : LFLAGS    = -m64 -static-intel -framework OpenGL -framework GLUT -mmacosx-version-min=10.4
-intel_osx_64 : CC        = icc 
+intel_osx_64 : CC        = icc
 intel_osx_64 : CPP       = icpc
 intel_osx_64 : FC        = ifort
 intel_osx_64 : exe       = smokeview_osx_$(SMV_TESTSTRING)64 $(SMV_PROFILESTRING)
@@ -235,7 +256,7 @@ intel_osx_64 : $(obj)
 intel_osx_64_db : FFLAGS    = -O0 -m64 -static-intel -fpp -D pp_OSX -mmacosx-version-min=10.4 -stand:f08
 intel_osx_64_db : CFLAGS    = -O0 -m64 -static-intel -D pp_OSX  -D pp_INTEL -mmacosx-version-min=10.4 $(SMV_TESTFLAG) $(SMV_PROFILEFLAG) $(GITINFO)
 intel_osx_64_db : LFLAGS    = -m64 -static-intel -framework OpenGL -framework GLUT -mmacosx-version-min=10.4
-intel_osx_64_db : CC        = icc 
+intel_osx_64_db : CC        = icc
 intel_osx_64_db : CPP       = icpc
 intel_osx_64_db : FC        = ifort
 intel_osx_64_db : exe       = smokeview_osx_$(SMV_TESTSTRING)64_db $(SMV_PROFILESTRING)

--- a/SMV/Build/mingw_win_64/make_smv.sh
+++ b/SMV/Build/mingw_win_64/make_smv.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+rm -rf *.o *.mod
+eval make -f ../Makefile mingw_win_64

--- a/SMV/source/glut-3.7.6/makelib.sh
+++ b/SMV/source/glut-3.7.6/makelib.sh
@@ -3,4 +3,4 @@ rm -f *.o
 source ../setopts.sh $*
 
 rm -f *.o
-eval make COMPILER=${COMPILER} SIZE=${SIZE} PLATFORM=\"${PLATFORM}\"
+eval make COMPILER=${COMPILER} SIZE=${SIZE} PLATFORM=\"${PLATFORM}\" ${TARGET}

--- a/SMV/source/shared/MALLOC.h
+++ b/SMV/source/shared/MALLOC.h
@@ -1,6 +1,10 @@
 #ifndef MALLOC_H_DEFINED
 #define MALLOC_H_DEFINED
 
+#ifdef __MINGW32__
+#include "options.h"
+#endif
+
 #ifdef pp_THREAD
 #include <pthread.h>
 #endif
@@ -38,8 +42,8 @@ typedef struct {
   int memory_id;
 #ifdef pp_MEMPRINT
   size_t size;
-#endif  
-  
+#endif
+
 } MMdata;
 
 MMEXTERN MMdata MMfirst, MMlast;
@@ -122,7 +126,7 @@ char *_strcat(char *s1, const char *s2);
 #define STRCAT(f,g) _strcat((f),(g))
 #else
 #define ValidPointer(pv,size)
-#define GetTotalMemory 
+#define GetTotalMemory
 #define CheckMemory
 #define CheckMemoryOn
 #define CheckMemoryOff

--- a/SMV/source/shared/file_util.h
+++ b/SMV/source/shared/file_util.h
@@ -2,6 +2,10 @@
 #define FILE_UTIL_H_DEFINED
 
 #include <time.h>
+#ifdef __MINGW32__
+#include <stdio.h>
+#include "options.h"
+#endif
 
 typedef struct {
   char *file;

--- a/SMV/source/shared/string_util.h
+++ b/SMV/source/shared/string_util.h
@@ -9,6 +9,11 @@
 #define STRDECL(var,val)  var
 #endif
 
+#ifdef __MINGW32__
+#include <stdio.h>
+#include "options.h"
+#endif
+
 #define MATCH 1
 #define NOTMATCH 0
 


### PR DESCRIPTION
Mingw and msys are used on Windows systems to utilise gcc for compilation.
This commit adds mingw as a build target. The change is mostly an addition
to the Makefile, and so should have no effect on other builds. Some header
files needed to have stdio.h and options.h included for definitions. These
have been placed under macros to only apply when using mingw.

Where files have been modified, trailing whitespace was removed
automatically. This has been left in as it is consistent with the coding
guidelines.
