### PR TITLE
smokeview source: remove unused variable declaration, define pp_SLICEDUP for all builds

### DIFF
--- a/SMV/source/smokeview/IOslice.c
+++ b/SMV/source/smokeview/IOslice.c
@@ -2691,7 +2691,7 @@ void update_fedinfo(void){
 /* ------------------ updatevslices ------------------------ */
 
 void updatevslices(void){
-  int i,ii;
+  int i;
 
   PRINTF("  updating vector slices\n");
   getsliceparams();

--- a/SMV/source/smokeview/options.h
+++ b/SMV/source/smokeview/options.h
@@ -39,6 +39,7 @@
 #define pp_THREAD
 #define pp_LANG
 #define pp_DEG
+#define pp_SLICEDUP
 
 #define _CRT_SECURE_NO_DEPRECATE
 
@@ -52,7 +53,6 @@
 #define pp_HAZARD
 //#define pp_GPUDEPTH
 #define pp_MEMPRINT
-#define pp_SLICEDUP
 #endif
 
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
smokeview source: remove unused variable declaration, define pp_SLICEDUP for all builds
