### PR TITLE
minor firebot and smokeview changes

### DIFF
--- a/SMV/Build/Makefile
+++ b/SMV/Build/Makefile
@@ -228,8 +228,8 @@ intel_linux_64_profile : $(obj)
 
 # ------------- gnu_linux_64_db ----------------
 
-gnu_linux_64_db : FFLAGS    = -O0 -m64 -x f95-cpp-input -D pp_GCC -D pp_noappend -ffree-form -frecord-marker=4
-gnu_linux_64_db : CFLAGS    = -O0 -m64 -D pp_LINUX
+gnu_linux_64_db : FFLAGS    = -O0 -m64 -ggdb -Wall -x f95-cpp-input -D pp_GCC -D pp_noappend -ffree-form -frecord-marker=4 -fcheck=all -fbacktrace
+gnu_linux_64_db : CFLAGS    = -O0 -m64 -ggdb -Wall -Wno-write-strings -D pp_LINUX
 gnu_linux_64_db : LFLAGS    = -m64
 gnu_linux_64_db : CC        = gcc
 gnu_linux_64_db : CPP       = g++

--- a/SMV/source/smokeview/IOslice.c
+++ b/SMV/source/smokeview/IOslice.c
@@ -2058,9 +2058,6 @@ int count_slicedups(void){
 
     mslicei = multisliceinfo + i;
     for(ii = 0; ii < mslicei->nslices; ii++){
-      slicedata *slicei;
-
-      slicei = sliceinfo + mslicei->islices[ii];
       count += is_slice_duplicate(mslicei, ii, COUNT_DUPLICATES);
     }
   }
@@ -6533,14 +6530,13 @@ int makeslicesizefile(char *file, char *sizefile, int compression_type){
   int endian_fromfile;
   float minmax[2];
   int ijkbar[6];
-  FILE *stream, *sizestream, *RLESLICEFILE;
+  FILE *stream, *sizestream;
   float time_local;
   int ncompressed;
   int count;
 
   stream=FOPEN(file,"rb");
   if(stream==NULL)return 0;
-  RLESLICEFILE=stream;
 
   sizestream=fopen(sizefile,"w");
   if(sizestream==NULL){

--- a/SMV/source/smokeview/getdata.f90
+++ b/SMV/source/smokeview/getdata.f90
@@ -779,8 +779,6 @@ if(testslice.eq.1.or.testslice.eq.2)then
   end do
 endif
 
-999 continue
-
 return
 end subroutine getsliceframe
 
@@ -792,9 +790,7 @@ character(len=*) :: endianfilename
 integer :: one
 integer :: file_unit
 
-file_unit=31
-
-call get_file_unit(file_unit,file_unit)
+call get_file_unit(file_unit,31)
 open(unit=file_unit,file=trim(endianfilename),form="unformatted")
 one=1
 write(31)one

--- a/SMV/source/smokeview/getsizes.f90
+++ b/SMV/source/smokeview/getsizes.f90
@@ -791,9 +791,12 @@ character(len=30) :: patchlonglabel, patchshortlabel, patchunit
 integer :: lu15
 logical :: exists
 logical :: isopen
+integer :: first_unit
+
+first_unit = boundaryunitnumber
 
 error=0
-call get_file_unit(boundaryunitnumber,boundaryunitnumber)
+call get_file_unit(boundaryunitnumber,first_unit)
 lu15 = boundaryunitnumber
 inquire(unit=lu15,opened=isopen)
 

--- a/Utilities/Firebot/cpu2plot.sh
+++ b/Utilities/Firebot/cpu2plot.sh
@@ -8,7 +8,7 @@ if [ ! -d $indir ]; then
   mkdir -p $indir
 fi
 cd $indir
-firebotdir=~/.firebot
+firebotdir=$HOME/.firebot
 if [ ! -d $firebotdir ]; then
   mkdir -p $firebotdir
 fi

--- a/Utilities/Firebot/firebot.sh
+++ b/Utilities/Firebot/firebot.sh
@@ -986,6 +986,7 @@ archive_timing_stats()
   echo $decdate,$TOTAL_FDS_TIMES>>$TIME_HISTORY
   if [ "$UPLOADGUIDES" == "1" ]; then
     cd $fdsrepo/Utilities/Firebot
+    sleep 1
     ./cpu2plot.sh -F
   fi
 }


### PR DESCRIPTION
smokeview source changes to remove a couple of gnu compiler warnings
use $HOME instead of ~ and add a sleep statement for generating cpu timing plots
