### PR TITLE
update user guide  - liquid fuel/0 cell floor

### DIFF
--- a/Manuals/FDS_User_Guide/FDS_User_Guide.tex
+++ b/Manuals/FDS_User_Guide/FDS_User_Guide.tex
@@ -5592,6 +5592,8 @@ burning rate will be adjusted to account for the difference between the heats of
 If a spray nozzle is used to generate the fuel droplets, its characteristics are specified
 in the same way as those for a sprinkler.  If the fuel species is present in the liquid properties table as a fuel, then the droplets will be given fuel radiation absorption properties.
 
+Note that to limit the computational cost of sprinkler simulations, liquid droplets disappear when they hit the ``floor'' of the computational domain, regardless of whether it is solid or not. However, this may not be desired when using liquid fuels. To stop FDS from removing liquid droplets from the floor of the domain, add the phrase {\ct POROUS\_FLOOR=.FALSE.} to the {\ct MISC} line. An altnerate solution is make sure the {\ct OBST} the fuel is landing on is at least one cell thick.
+
 \subsubsection{Example Case: spray\_burner}
 
 Controlled fire experiments are often conducted using a spray burner,


### PR DESCRIPTION
I was running a whole bunch of simulations with heptane spray burner. I had a zero cell floor and kept losing my fuel. In debugging I found a 1 cell floor fixed this issue. Wasn't until talking with @drjfloyd that I knew about this POROUS_FLOOR. Added discussion in Fuel Droplets sections to inform users and future Craig.
