### PR TITLE
repo: revert line ending settings back to lf for text files (except f…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,24 +4,24 @@
 * text=auto
 
 # Declare files that will always have LF line endings on checkout.
-*.fds text
-*.smv text
-*.ini text
-*.ssf text
-*.lua text
-*.tex text
-*.csv text
-*.f90 text
-*.f text
-*.m text
-*.c text
-*.h text
-makefile text
-*.md text
-*.py text
-*.sh text
+*.fds text eol=lf
+*.smv text eol=lf
+*.ini text eol=lf
+*.ssf text eol=lf
+*.lua text eol=lf
+*.tex text eol=lf
+*.csv text eol=lf
+*.f90 text eol=lf
+*.f text eol=lf
+*.m text eol=lf
+*.c text eol=lf
+*.h text eol=lf
+makefile text eol=lf
+*.md text eol=lf
+*.py text eol=lf
+*.sh text eol=lf
 *.bat text
-*.csh text
+*.csh text eol=lf
 
 # Denote all files that are truly binary and should not be modified.
 *.png binary


### PR DESCRIPTION
…or .bat files)
