### PR TITLE
FDS verification: corrected typo in veri' guide

### DIFF
--- a/Manuals/FDS_Verification_Guide/FDS_Verification_Guide.tex
+++ b/Manuals/FDS_Verification_Guide/FDS_Verification_Guide.tex
@@ -608,7 +608,7 @@ of velocity, $(x_{N/2},\bar{z}_{N/2})$, which is different in each case, $N =\{8
    \end{tabular*}
    \caption[Velocity time history, qualitative convergence]{Time history of the $u$-component of velocity half a grid cell below the center of the domain for a range of grid resolutions.
    The domain is a square of side $L = 2\pi$ m.  The $N \times N$ grid is uniform.  Progressing from left to right and top to bottom we have resolutions $N =\{8,16,32,64\}$
-   clearly showing convergence of the FDS numerical solution (open circles) to the analytical solution (solid line).
+   clearly showing convergence of the FDS numerical solution (dotted line) to the analytical solution (solid line).
    The case is run with constant properties, $\rho=1$ \si{kg/m^3} and $\mu = 0.1$ kg/m/s, and a Courant-Friedrichs-Lewy (CFL) of 0.25.}
    \label{fig_ns2d_timehistory}
 \end{figure}


### PR DESCRIPTION
Minor/historic typo re description of plots (text says open circles, plots are dotted lines). Corrected.
