### PR TITLE
smv build: change if to ifeq on link line for LUA processing - 'if' wa…

### DIFF
--- a/SMV/Build/smokeview/Makefile
+++ b/SMV/Build/smokeview/Makefile
@@ -197,7 +197,7 @@ intel_linux_64 : CPP       = icpc
 intel_linux_64 : FC        = ifort
 intel_linux_64 : exe       = smokeview_linux_$(SMV_TESTSTRING)64$(SMV_PROFILESTRING)
 
-intel_linux_64 : $(obj)  $(if ($(LUA_SCRIPTING),true),smvluacore)
+intel_linux_64 : $(obj)  $(ifeq ($(LUA_SCRIPTING),true),smvluacore)
 	$(CPP) -o $(bin)/$(exe) $(obj) $(LFLAGS) -L$(LIB_DIR_PLAT) $(SMV_LIBS_LINUX) \
         $(INTEL_LIBS_LINUX)\
         $(SYSTEM_LIBS_LINUX) $(LIBLUA)
@@ -259,10 +259,10 @@ gnu_linux_64 : CPP       = g++
 gnu_linux_64 : FC        = gfortran
 gnu_linux_64 : exe       = smokeview_linux_$(SMV_TESTSTRING)64
 
-gnu_linux_64 : $(obj) $(if ($(LUA_SCRIPTING),true),smvluacore)
+gnu_linux_64 : $(obj) $(ifeq ($(LUA_SCRIPTING),true),smvluacore)
 	$(CPP) -o $(bin)/$(exe) $(obj) $(LFLAGS) -L $(LIB_DIR_PLAT) \
 		$(SMV_LIBS_LINUX) -lgfortran $(SYSTEM_LIBS_LINUX) \
-		$(if ($(LUA_SCRIPTING),true),$(LIB_DIR_PLAT)/liblua.a -ldl)
+		$(ifeq ($(LUA_SCRIPTING),true),$(LIB_DIR_PLAT)/liblua.a -ldl)
 
 # ------------- mingw_win_64 ----------------
 
@@ -286,7 +286,7 @@ mingw_win_64 : CPP       = g++
 mingw_win_64 : FC        = gfortran
 mingw_win_64 : exe       = smokeview_mingw_$(SMV_TESTSTRING)64
 
-mingw_win_64 : $(obj) $(if ($(LUA_SCRIPTING),true),smvluacore)
+mingw_win_64 : $(obj) $(ifeq ($(LUA_SCRIPTING),true),smvluacore)
 	$(CPP) -o $(bin)/$(exe) $(obj) $(LFLAGS) -L $(LIB_DIR_PLAT) \
 		$(($(LUA_SCRIPTING),true),-I $(SOURCE_DIR)/lua-5.3.1/src) \
 		$(LIBS_PLAT) -lgfortran -lm -lopengl32 -lglu32 \
@@ -318,7 +318,7 @@ intel_osx_64 : CPP       = icpc
 intel_osx_64 : FC        = ifort
 intel_osx_64 : exe       = smokeview_osx_$(SMV_TESTSTRING)64 $(SMV_PROFILESTRING)
 
-intel_osx_64 : $(obj) $(if ($(LUA_SCRIPTING),true),smvluacore)
+intel_osx_64 : $(obj) $(ifeq ($(LUA_SCRIPTING),true),smvluacore)
 	icpc -o $(bin)/$(exe) $(LFLAGS) $(obj)  -L $(LIB_DIR_PLAT) $(SMV_LIBS_OSX) \
         $(OSX_INTEL_LIBS) $(LIBLUA)
 


### PR DESCRIPTION
…s not working

LUA_SCRIPTING

IF LUA_SCRIPTING is false, the line (before this pull request)
 $(if ($(LUA_SCRIPTING),true),smvluacore) 
found on various link lines in the smokeview makeifile causes smvluacore to be processed/included.  Likewise if LUA_SCRIPTING is false, no LUA elements should be included in a smokeview build.  
The problem was that smvluacore was processed and lua files were included when building smokeview even when LUA_SCRIPTING was set to false.  This pull request changes if to ifeq in the above line.  Now smokeview does not include any lua elements when LUA_SCRIPTING is false.

I was not able to test whether ifeq works when LUA_SCRIPTING is true.  Jake can you check this.
thanks,
glenn
