### PR TITLE
Correct cleaning of Lua files.

### DIFF
--- a/SMV/Build/smokeview/Makefile
+++ b/SMV/Build/smokeview/Makefile
@@ -50,7 +50,7 @@ endif
 
 objwin = $(obj:.o=.obj)
 
-INC = -I $(SOURCE_DIR)/glut-3.7.6 -I $(SOURCE_DIR)/glui_v2_1_beta -I $(SOURCE_DIR)/gd-2.0.15 -I $(SOURCE_DIR)/shared -I $(SOURCE_DIR)/smokeview -I $(SOURCE_DIR)/glew -I $(SOURCE_DIR)/zlib128 
+INC = -I $(SOURCE_DIR)/glut-3.7.6 -I $(SOURCE_DIR)/glui_v2_1_beta -I $(SOURCE_DIR)/gd-2.0.15 -I $(SOURCE_DIR)/shared -I $(SOURCE_DIR)/smokeview -I $(SOURCE_DIR)/glew -I $(SOURCE_DIR)/zlib128
 WININC = -I $(SOURCE_DIR)/GLINC -I $(SOURCE_DIR)/pthreads
 
 ifeq ($(LUA_SCRIPTING),true)
@@ -365,7 +365,7 @@ gnu_osx_64 : $(obj)
 
 .PHONY : clean
 clean:
-	rm -f *.o *.mod
+	rm -f *.o *.mod *.lua *.dll
 
 #-------------- force compilation of string_util.c -----------
 

--- a/SMV/Build/smokeview/Makefile
+++ b/SMV/Build/smokeview/Makefile
@@ -197,7 +197,7 @@ intel_linux_64 : CPP       = icpc
 intel_linux_64 : FC        = ifort
 intel_linux_64 : exe       = smokeview_linux_$(SMV_TESTSTRING)64$(SMV_PROFILESTRING)
 
-intel_linux_64 : $(obj)  $(ifeq ($(LUA_SCRIPTING),true),smvluacore)
+intel_linux_64 : $(obj)  $(if ($(LUA_SCRIPTING),true),smvluacore)
 	$(CPP) -o $(bin)/$(exe) $(obj) $(LFLAGS) -L$(LIB_DIR_PLAT) $(SMV_LIBS_LINUX) \
         $(INTEL_LIBS_LINUX)\
         $(SYSTEM_LIBS_LINUX) $(LIBLUA)
@@ -259,10 +259,10 @@ gnu_linux_64 : CPP       = g++
 gnu_linux_64 : FC        = gfortran
 gnu_linux_64 : exe       = smokeview_linux_$(SMV_TESTSTRING)64
 
-gnu_linux_64 : $(obj) $(ifeq ($(LUA_SCRIPTING),true),smvluacore)
+gnu_linux_64 : $(obj) $(if ($(LUA_SCRIPTING),true),smvluacore)
 	$(CPP) -o $(bin)/$(exe) $(obj) $(LFLAGS) -L $(LIB_DIR_PLAT) \
 		$(SMV_LIBS_LINUX) -lgfortran $(SYSTEM_LIBS_LINUX) \
-		$(ifeq ($(LUA_SCRIPTING),true),$(LIB_DIR_PLAT)/liblua.a -ldl)
+		$(if ($(LUA_SCRIPTING),true),$(LIB_DIR_PLAT)/liblua.a -ldl)
 
 # ------------- mingw_win_64 ----------------
 
@@ -286,7 +286,7 @@ mingw_win_64 : CPP       = g++
 mingw_win_64 : FC        = gfortran
 mingw_win_64 : exe       = smokeview_mingw_$(SMV_TESTSTRING)64
 
-mingw_win_64 : $(obj) $(ifeq ($(LUA_SCRIPTING),true),smvluacore)
+mingw_win_64 : $(obj) $(if ($(LUA_SCRIPTING),true),smvluacore)
 	$(CPP) -o $(bin)/$(exe) $(obj) $(LFLAGS) -L $(LIB_DIR_PLAT) \
 		$(($(LUA_SCRIPTING),true),-I $(SOURCE_DIR)/lua-5.3.1/src) \
 		$(LIBS_PLAT) -lgfortran -lm -lopengl32 -lglu32 \
@@ -318,7 +318,7 @@ intel_osx_64 : CPP       = icpc
 intel_osx_64 : FC        = ifort
 intel_osx_64 : exe       = smokeview_osx_$(SMV_TESTSTRING)64 $(SMV_PROFILESTRING)
 
-intel_osx_64 : $(obj) $(ifeq ($(LUA_SCRIPTING),true),smvluacore)
+intel_osx_64 : $(obj) $(if ($(LUA_SCRIPTING),true),smvluacore)
 	icpc -o $(bin)/$(exe) $(LFLAGS) $(obj)  -L $(LIB_DIR_PLAT) $(SMV_LIBS_OSX) \
         $(OSX_INTEL_LIBS) $(LIBLUA)
 

--- a/SMV/Build/smokeview/Makefile
+++ b/SMV/Build/smokeview/Makefile
@@ -11,7 +11,7 @@ SMV_TESTFLAG =
 SMV_TESTSTRING =
 SMV_PROFILEFLAG =
 SMV_PROFILESTRING =
-LUA_SCRIPTING = false
+LUA_SCRIPTING =
 ifeq ($(shell echo "check_quotes"),"check_quotes")
   GIT_HASH := $(shell ..\..\..\..\Utilities\Scripts\githash)
   GIT_DATE := $(shell ..\..\..\..\Utilities\Scripts\gitlog)
@@ -197,7 +197,7 @@ intel_linux_64 : CPP       = icpc
 intel_linux_64 : FC        = ifort
 intel_linux_64 : exe       = smokeview_linux_$(SMV_TESTSTRING)64$(SMV_PROFILESTRING)
 
-intel_linux_64 : $(obj)  $(if ($(LUA_SCRIPTING),true),smvluacore)
+intel_linux_64 : $(obj)  $(if $(LUA_SCRIPTING),smvluacore)
 	$(CPP) -o $(bin)/$(exe) $(obj) $(LFLAGS) -L$(LIB_DIR_PLAT) $(SMV_LIBS_LINUX) \
         $(INTEL_LIBS_LINUX)\
         $(SYSTEM_LIBS_LINUX) $(LIBLUA)
@@ -259,10 +259,10 @@ gnu_linux_64 : CPP       = g++
 gnu_linux_64 : FC        = gfortran
 gnu_linux_64 : exe       = smokeview_linux_$(SMV_TESTSTRING)64
 
-gnu_linux_64 : $(obj) $(if ($(LUA_SCRIPTING),true),smvluacore)
+gnu_linux_64 : $(obj) $(if $(LUA_SCRIPTING),smvluacore)
 	$(CPP) -o $(bin)/$(exe) $(obj) $(LFLAGS) -L $(LIB_DIR_PLAT) \
 		$(SMV_LIBS_LINUX) -lgfortran $(SYSTEM_LIBS_LINUX) \
-		$(if ($(LUA_SCRIPTING),true),$(LIB_DIR_PLAT)/liblua.a -ldl)
+		$(if $(LUA_SCRIPTING),$(LIB_DIR_PLAT)/liblua.a -ldl)
 
 # ------------- mingw_win_64 ----------------
 
@@ -286,12 +286,11 @@ mingw_win_64 : CPP       = g++
 mingw_win_64 : FC        = gfortran
 mingw_win_64 : exe       = smokeview_mingw_$(SMV_TESTSTRING)64
 
-mingw_win_64 : $(obj) $(if ($(LUA_SCRIPTING),true),smvluacore)
+mingw_win_64 : $(obj) $(if $(LUA_SCRIPTING),smvluacore)
 	$(CPP) -o $(bin)/$(exe) $(obj) $(LFLAGS) -L $(LIB_DIR_PLAT) \
 		$(($(LUA_SCRIPTING),true),-I $(SOURCE_DIR)/lua-5.3.1/src) \
 		$(LIBS_PLAT) -lgfortran -lm -lopengl32 -lglu32 \
 		-lgdi32 -lwinmm -lcomdlg32 -lpthread
-	echo $(SMVLUACORE_FILES)
 
 # VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
 # VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV   OSX   VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV
@@ -318,7 +317,7 @@ intel_osx_64 : CPP       = icpc
 intel_osx_64 : FC        = ifort
 intel_osx_64 : exe       = smokeview_osx_$(SMV_TESTSTRING)64 $(SMV_PROFILESTRING)
 
-intel_osx_64 : $(obj) $(if ($(LUA_SCRIPTING),true),smvluacore)
+intel_osx_64 : $(obj) $(if $(LUA_SCRIPTING),smvluacore)
 	icpc -o $(bin)/$(exe) $(LFLAGS) $(obj)  -L $(LIB_DIR_PLAT) $(SMV_LIBS_OSX) \
         $(OSX_INTEL_LIBS) $(LIBLUA)
 

--- a/SMV/Build/smokeview/Makefile
+++ b/SMV/Build/smokeview/Makefile
@@ -365,7 +365,7 @@ gnu_osx_64 : $(obj)
 
 .PHONY : clean
 clean:
-	rm -f *.o *.mod *.lua *.dll
+	rm -f *.o *.mod *.lua *.dll *.so
 
 #-------------- force compilation of string_util.c -----------
 

--- a/SMV/Build/smokeview/mingw_win_64/make_smv.sh
+++ b/SMV/Build/smokeview/mingw_win_64/make_smv.sh
@@ -1,3 +1,7 @@
-#!/bin/bash
-rm -rf *.o *.mod
-eval make -f ../Makefile mingw_win_64
+# !/bin/bash
+# source ../../scripts/setopts.sh $*
+LIBDIR=../../LIBS/lib_win_mingw_64/
+source ../../scripts/test_libs.sh
+
+make -f ../Makefile clean
+eval make -j 4 ${SMV_MAKE_OPTS} -f ../Makefile mingw_win_64

--- a/SMV/source/smokeview/c_api.c
+++ b/SMV/source/smokeview/c_api.c
@@ -452,7 +452,7 @@ char* form_filename(int view_mode, char *renderfile_name, char *renderfile_dir,
     char* view_suffix;
 
     // determine the extension to be used, and set renderfile_ext to it
-    switch(renderfiletype) {
+    switch(render_filetype) {
         case 0:
             renderfile_ext = ext_png;
             break;
@@ -460,7 +460,7 @@ char* form_filename(int view_mode, char *renderfile_name, char *renderfile_dir,
             renderfile_ext = ext_jpg;
             break;
         default:
-            renderfiletype = 2;
+            render_filetype = 2;
             renderfile_ext = ext_png;
             break;
     }
@@ -568,7 +568,7 @@ int RenderFrameLua(int view_mode, const char *basename) {
 
   printf("renderfile_name: %s\n", renderfile_name);
   // render image
-  return_code = SVimage2file(renderfile_dir,renderfile_name,renderfiletype,
+  return_code = SVimage2file(renderfile_dir,renderfile_name,render_filetype,
                              woffset,screenWidth,hoffset,screenH);
   if(RenderTime==1&&output_slicedata==1){
     output_Slicedata();
@@ -594,7 +594,7 @@ int RenderFrameLuaVar(int view_mode, gdImagePtr *RENDERimage) {
   // we should not be rendering under these conditions
   if(view_mode==VIEW_LEFT&&showstereo==STEREO_RB)return 0;
   // render image
-  return_code = SVimage2var(renderfiletype,
+  return_code = SVimage2var(render_filetype,
                              woffset,screenWidth,hoffset,screenH, RENDERimage);
   if(RenderTime==1&&output_slicedata==1){
     output_Slicedata();
@@ -1317,7 +1317,7 @@ void rendertype(const char *type) {
 }
 
 int get_rendertype() {
-    return renderfiletype;
+    return render_filetype;
 }
 
 void set_movietype(const char *type) {
@@ -1333,7 +1333,7 @@ void set_movietype(const char *type) {
 }
 
 int get_movietype() {
-    return moviefiletype;
+    return movie_filetype;
 }
 
 void makemovie(const char *name, const char *base, float framerate) {
@@ -3199,8 +3199,8 @@ int set_renderfilelabel(int v) {
 } // RENDERFILELABEL
 
 int set_renderfiletype(int render, int movie) {
-  renderfiletype = render;
-  moviefiletype = movie;
+  render_filetype = render;
+  movie_filetype = movie;
   return 0;
 } // RENDERFILETYPE
 


### PR DESCRIPTION
Revert #4112 and return to using `if` not `ifeq`. `ifeq` is only applicable at the root level, and not in expressions where `if` must be used. Currently the lua files are never included, regardless of whether `LUA_SCRIPTING` is true.

However, the previous conditionals were also incorrect. It seems quite convoluted to include a proper equality check here, so I've modified the `LUA_SCRIPTING` variable such that the false value is the empty string. This way both types of conditionals will work correctly (any value of `LUA_SCRIPTING` which is not the empty string results in true). I've tested on mingw and gnu_linux, and it seems to be working fine.

I've also updated the Makefile to properly clean up lua files. This pull request also includes some minor variable name updates in the lua code to sync with recent changes.
