### PR TITLE
Matlab: make FDS_validation_script a function call

### DIFF
--- a/Utilities/Matlab/FDS_validation_script.m
+++ b/Utilities/Matlab/FDS_validation_script.m
@@ -23,20 +23,31 @@
 % Dataplot creates most of the plots for the Validation Guide.
 % It must be run before scatplot, which makes the scatter plots.
 
-close all
-clear all
+function [] = FDS_validation_script(varargin)
 
 addpath 'scripts'
 
+% Process variable argument list
+
+skip_to_dataplot=false;
+if nargin>0
+    skip_to_dataplot=true;
+else
+    close all
+    clear all
+end
+
 % Scripts that run prior to dataplot
 
-flame_height
-cat_mccaffrey
-NIST_RSE
-sippola_aerosol_deposition
-layer_height
-combine_csiro
-fm_datacenter_scatter
+if ~skip_to_dataplot
+    flame_height
+    cat_mccaffrey
+    NIST_RSE
+    sippola_aerosol_deposition
+    layer_height
+    combine_csiro
+    fm_datacenter_scatter
+end
 
 % Dataplot and scatplot options
 
@@ -59,7 +70,9 @@ Append_To_Scatterplot_Title = '';
 
 % Run dataplot and scatplot scripts
 
-[saved_data,drange] = dataplot(Dataplot_Inputs_File, Working_Dir, Manuals_Dir);
+varargin
+
+[saved_data,drange] = dataplot(Dataplot_Inputs_File, Working_Dir, Manuals_Dir, varargin);
 scatplot(saved_data, drange, ...
          'Manuals_Dir', Manuals_Dir, ...
          'Scatterplot_Inputs_File', Scatterplot_Inputs_File, ...
@@ -72,18 +85,20 @@ scatplot(saved_data, drange, ...
      
 % Miscellaneous other scripts for special cases
 
-backward_facing_step
-beyler_hood
-sandia_helium_plume
-sandia_methane_fire
-spray_attenuation
-Cup_burner
-flame_height2
-purdue_flames
-christifire
-pressure_coefficient
-VTT_Sprays
-fm_datacenter_veltest
-umd_line_burner
+if ~skip_to_dataplot
+    backward_facing_step
+    beyler_hood
+    sandia_helium_plume
+    sandia_methane_fire
+    spray_attenuation
+    Cup_burner
+    flame_height2
+    purdue_flames
+    christifire
+    pressure_coefficient
+    VTT_Sprays
+    fm_datacenter_veltest
+    umd_line_burner
+end
 
 display('validation scripts completed successfully!')

--- a/Utilities/Matlab/FDS_validation_script.m
+++ b/Utilities/Matlab/FDS_validation_script.m
@@ -7,16 +7,22 @@
 % subfolder called "scripts". 
 %
 % The most important script is called dataplot. It reads the file called
-% FDS_validation_dataplot_inputs.csv and generates 1000+ plots. If you
-% want to process only some of these plots, comment out the other 
-% scripts and change the data plot line as follows:
+% FDS_validation_dataplot_inputs.csv and generates 1000+ plots.
 %
-% [saved_data,drange] = dataplot(Dataplot_Inputs_File,Validation_Dir,Manuals_Dir,[a:b]);
+% Usage:
 %
-% where a and b are the lines in the .csv file you want to process.
-% Alternatively, you can specify the "Dataname" you want:
+% >> FDS_validation_script([drange]);
 %
-% [saved_data,drange] = dataplot(Dataplot_Inputs_File,Validation_Dir,Manuals_Dir,'WTC');
+% where drange is an optional argument.
+%
+% If you know the lines in the .csv file you want to process, set drange = [a:b],
+% where a and b are the start and finish of the lines to be processed.  Note that
+% drange is simply a list of array elements, so it is permissible to use, for example,
+% [a:b,c].
+%
+% Alternatively, you can specify the "Dataname" for the case you want to plot:
+%
+% >> FDS_validation_script('WTC');
 %
 % In this case, all the WTC results will be plotted.
 %
@@ -39,14 +45,29 @@ end
 
 % Scripts that run prior to dataplot
 
-if ~skip_to_dataplot
-    flame_height
-    cat_mccaffrey
-    NIST_RSE
-    sippola_aerosol_deposition
-    layer_height
-    combine_csiro
-    fm_datacenter_scatter
+switch varargin
+    case {'Heskestad Flame Height'}
+        flame_height
+    case {'McCaffrey Plume'}
+        cat_mccaffrey
+    case {'NIST RSE 1994'}
+        NIST_RSE
+    case {'Sippola Aerosol Deposition'}
+        sippola_aerosol_deposition
+    case {'ATF Corridors','FM/SNL','NIST FSE 2008','NIST/NRC','NRCC Smoke Tower','PRISME','UL/NIST Vents','VTT','WTC'}
+        layer_height
+    case {'CSIRO Grassland Fires'}
+        combine_csiro
+    case {'FM Datacenter'}
+        fm_datacenter_scatter
+    otherwise
+        flame_height
+        cat_mccaffrey
+        NIST_RSE
+        sippola_aerosol_deposition
+        layer_height
+        combine_csiro
+        fm_datacenter_scatter
 end
 
 % Dataplot and scatplot options

--- a/Utilities/Matlab/FDS_validation_script.m
+++ b/Utilities/Matlab/FDS_validation_script.m
@@ -31,82 +31,22 @@
 
 function [] = FDS_validation_script(varargin)
 
+close all
+clearvars -except varargin
+
 addpath 'scripts'
 
 % Process variable argument list
 
-skip_to_dataplot=false;
+run_subset=false;
+run_dataplot=true;
 if nargin>0
-    skip_to_dataplot=true;
-else
-    close all
-    clear all
+    run_subset=true;
 end
 
-% Scripts that run prior to dataplot
-
-switch varargin
-    case {'Heskestad Flame Height'}
-        flame_height
-    case {'McCaffrey Plume'}
-        cat_mccaffrey
-    case {'NIST RSE 1994'}
-        NIST_RSE
-    case {'Sippola Aerosol Deposition'}
-        sippola_aerosol_deposition
-    case {'ATF Corridors','FM/SNL','NIST FSE 2008','NIST/NRC','NRCC Smoke Tower','PRISME','UL/NIST Vents','VTT','WTC'}
-        layer_height
-    case {'CSIRO Grassland Fires'}
-        combine_csiro
-    case {'FM Datacenter'}
-        fm_datacenter_scatter
-    otherwise
-        flame_height
-        cat_mccaffrey
-        NIST_RSE
-        sippola_aerosol_deposition
-        layer_height
-        combine_csiro
-        fm_datacenter_scatter
-end
-
-% Dataplot and scatplot options
-
-Dataplot_Inputs_File = [pwd,'/FDS_validation_dataplot_inputs.csv'];
-Working_Dir = [pwd, '/../../Validation/'];
-Manuals_Dir = [pwd, '/../../Manuals/'];
-Scatterplot_Inputs_File = [pwd, '/FDS_validation_scatterplot_inputs.csv'];
-
-% Statistics output options
-
-Stats_Output = 'Validation';
-Output_File = [pwd, '/FDS_validation_scatterplot_output.csv'];
-Statistics_Tex_Output = [pwd, '/../../Manuals/FDS_Validation_Guide/SCRIPT_FIGURES/ScatterPlots/validation_statistics.tex'];
-Histogram_Tex_Output = [pwd, '/../../Manuals/FDS_Validation_Guide/SCRIPT_FIGURES/ScatterPlots/validation_histograms.tex'];
-
-% Override the plot style options with NRC 1824 plot options
-
-NRC_Options = false;
-Append_To_Scatterplot_Title = '';
-
-% Run dataplot and scatplot scripts
-
-varargin
-
-[saved_data,drange] = dataplot(Dataplot_Inputs_File, Working_Dir, Manuals_Dir, varargin);
-scatplot(saved_data, drange, ...
-         'Manuals_Dir', Manuals_Dir, ...
-         'Scatterplot_Inputs_File', Scatterplot_Inputs_File, ...
-         'Stats_Output', Stats_Output, ...
-         'Output_File', Output_File, ...
-         'Statistics_Tex_Output', Statistics_Tex_Output, ...
-         'Histogram_Tex_Output', Histogram_Tex_Output, ...
-         'NRC_Options', NRC_Options, ...
-         'Append_To_Scatterplot_Title', Append_To_Scatterplot_Title)
-     
 % Miscellaneous other scripts for special cases
 
-if ~skip_to_dataplot
+if ~run_subset % subset_if_1
     backward_facing_step
     beyler_hood
     sandia_helium_plume
@@ -120,6 +60,87 @@ if ~skip_to_dataplot
     VTT_Sprays
     fm_datacenter_veltest
     umd_line_burner
-end
+else
+    switch varargin{1}
+        case {'backward_facing_step'};  backward_facing_step;  run_dataplot=false;
+        case {'beyler_hood'}         ;  beyler_hood;           run_dataplot=false;
+        case {'sandia_helium_plume'};   sandia_helium_plume;   run_dataplot=false;
+        case {'sandia_methane_fire'};   sandia_methane_fire;   run_dataplot=false;
+        case {'spray_attenuation'};     spray_attenuation;     run_dataplot=false;
+        case {'Cup_burner'};            Cup_burner;            run_dataplot=false;
+        case {'flame_height2'};         flame_height2;         run_dataplot=false;
+        case {'purdue_flames'};         purdue_flames;         run_dataplot=false;
+        case {'christifire'};           christifire;           run_dataplot=false;
+        case {'pressure_coefficient'};  pressure_coefficient;  run_dataplot=false;
+        case {'VTT_Sprays'};            VTT_Sprays;            run_dataplot=false;
+        case {'fm_datacenter_veltest'}; fm_datacenter_veltest; run_dataplot=false;
+        case {'umd_line_burner'};       umd_line_burner;       run_dataplot=false;
+    end
+end % subset_if_1
+
+if run_dataplot % dataplot_if
+
+    % Scripts that run prior to dataplot
+
+    if ~run_subset % subset_if_2
+        flame_height
+        cat_mccaffrey
+        NIST_RSE
+        sippola_aerosol_deposition
+        layer_height
+        combine_csiro
+        fm_datacenter_scatter
+    else
+        switch varargin{1}
+            case {'Heskestad Flame Height'}
+                flame_height
+            case {'McCaffrey Plume'}
+                cat_mccaffrey
+            case {'NIST RSE 1994'}
+                NIST_RSE
+            case {'Sippola Aerosol Deposition'}
+                sippola_aerosol_deposition
+            case {'ATF Corridors','FM/SNL','NIST FSE 2008','NIST/NRC','NRCC Smoke Tower','PRISME','UL/NIST Vents','VTT','WTC'}
+                layer_height
+            case {'CSIRO Grassland Fires'}
+                combine_csiro
+            case {'FM Datacenter'}
+                fm_datacenter_scatter
+        end
+    end % subset_if_2
+
+    % Dataplot and scatplot options
+
+    Dataplot_Inputs_File = [pwd,'/FDS_validation_dataplot_inputs.csv'];
+    Working_Dir = [pwd, '/../../Validation/'];
+    Manuals_Dir = [pwd, '/../../Manuals/'];
+    Scatterplot_Inputs_File = [pwd, '/FDS_validation_scatterplot_inputs.csv'];
+
+    % Statistics output options
+
+    Stats_Output = 'Validation';
+    Output_File = [pwd, '/FDS_validation_scatterplot_output.csv'];
+    Statistics_Tex_Output = [pwd, '/../../Manuals/FDS_Validation_Guide/SCRIPT_FIGURES/ScatterPlots/validation_statistics.tex'];
+    Histogram_Tex_Output = [pwd, '/../../Manuals/FDS_Validation_Guide/SCRIPT_FIGURES/ScatterPlots/validation_histograms.tex'];
+
+    % Override the plot style options with NRC 1824 plot options
+
+    NRC_Options = false;
+    Append_To_Scatterplot_Title = '';
+
+    % Run dataplot and scatplot scripts
+
+    [saved_data,drange] = dataplot(Dataplot_Inputs_File, Working_Dir, Manuals_Dir, varargin);
+    scatplot(saved_data, drange, ...
+             'Manuals_Dir', Manuals_Dir, ...
+             'Scatterplot_Inputs_File', Scatterplot_Inputs_File, ...
+             'Stats_Output', Stats_Output, ...
+             'Output_File', Output_File, ...
+             'Statistics_Tex_Output', Statistics_Tex_Output, ...
+             'Histogram_Tex_Output', Histogram_Tex_Output, ...
+             'NRC_Options', NRC_Options, ...
+             'Append_To_Scatterplot_Title', Append_To_Scatterplot_Title)
+
+end  % dataplot_if
 
 display('validation scripts completed successfully!')


### PR DESCRIPTION
With this change you can now run, for example, FDS_validation_script('WTC') to only plot the WTC cases without having to manually comment the other scripts and/or add WTC into the FDS_validation_script (which then has to be checked out again to clean up).  Let me know if you have any problems.
