### PR TITLE
Evacuation: Source code fixes, new Evac version 2.5.2 number

### DIFF
--- a/Source/evac.f90
+++ b/Source/evac.f90
@@ -44,7 +44,7 @@ MODULE EVAC
        EMESH_INDEX, HUMAN_SMOKE_HEIGHT, EVAC_DELTA_SEE, EVAC_EMESH_STAIRS_TYPE, EMESH_STAIRS
   PUBLIC NO_EVAC_MESHES, INPUT_EVAC_GRIDS
   !
-  CHARACTER(255):: EVAC_VERSION = '2.5.1'
+  CHARACTER(255):: EVAC_VERSION = '2.5.2'
   CHARACTER(255) :: EVAC_COMPILE_DATE
   INTEGER :: EVAC_MODULE_REV
 
@@ -15271,7 +15271,7 @@ CONTAINS
     IF (ABS(i_r2-i_r1)+ABS(j_r2-j_r1) < 1) RETURN
 
     ! Choose the main direction:
-    IF (ABS(i_r2-i_r1) < ABS(j_r2-j_r1)) THEN
+    IF (ABS(r2_x-r1_x)/M%DX(1) < ABS(r2_y-r1_y)/M%DY(1)) THEN
        ! Now y is the main direction
        i_old = i_r1 ; j_old = j_r1
        y = 0.0_EB
@@ -15379,7 +15379,6 @@ CONTAINS
     i_r2 = MAX(1,MIN(i_r2,MFF%IBAR))
     j_r1 = MAX(1,MIN(j_r1,MFF%JBAR))
     j_r2 = MAX(1,MIN(j_r2,MFF%JBAR))
-
     ! Same cell: sees always each other
     IF (ABS(i_r2-i_r1)+ABS(j_r2-j_r1) < 1) THEN
        ave_K = EVAC_MASS_EXTINCTION_COEFF*1.0E-6_EB*M%HUMAN_GRID(i_r1,j_r1)%SOOT_DENS
@@ -15388,7 +15387,7 @@ CONTAINS
     END IF
 
     ! Choose the main direction:
-    IF (ABS(i_r2-i_r1) < ABS(j_r2-j_r1)) THEN
+    IF (ABS(r2_x-r1_x)/MFF%DX(1) < ABS(r2_y-r1_y)/MFF%DY(1)) THEN
        ! Now y is the main direction
 
        ! Add the last cell (r1) to the average
@@ -16115,9 +16114,11 @@ CONTAINS
           IF (ABS(DOOR_IOR)==1)THEN
              Y1 = Y_XYZ - 0.5_EB*DOOR_WIDTH + MIN(0.3_EB,0.5_EB*DOOR_WIDTH)
              Y2 = Y_XYZ + 0.5_EB*DOOR_WIDTH - MIN(0.3_EB,0.5_EB*DOOR_WIDTH)
+             X1 = X_XYZ ; X2 = X_XYZ
           ELSE
              X1 = X_XYZ - 0.5_EB*DOOR_WIDTH + MIN(0.3_EB,0.5_EB*DOOR_WIDTH)
              X2 = X_XYZ + 0.5_EB*DOOR_WIDTH - MIN(0.3_EB,0.5_EB*DOOR_WIDTH)
+             Y1 = Y_XYZ ; Y2 = Y_XYZ
           END IF
           PP_see_door = See_each_other(nm_tmp, x1_old, y1_old, x1, y1)
           Is_BeeLine_Door(i,2) = PP_see_door
@@ -16143,7 +16144,7 @@ CONTAINS
           END IF
           PP_see_door = See_each_other(nm_tmp, x1_old, y1_old, x11, y11)
           Is_BeeLine_Door(i,1) = PP_see_door
-          PP_see_door = See_door(nm_tmp, x1_old, y1_old, x11, y11, ave_K, max_fed)
+          PP_see_door   = See_door(nm_tmp, x1_old, y1_old, x11, y11, ave_K, max_fed)
           PP_see_doorXB = See_door(nm_tmp, x1_old, y1_old, XBx, XBy, ave_K2, max_fed2) .AND. PP_correct_side
           IF (PP_see_doorXB .AND. .NOT.PP_see_door) THEN
              max_fed = max_fed2 ; ave_K = ave_K2
@@ -16152,6 +16153,7 @@ CONTAINS
              max_fed = MIN(max_fed, max_fed2) ; ave_K = MIN(ave_K, ave_K2)
           END IF
           PP_see_door = PP_see_door .OR. (PP_see_doorXB .AND. PP_correct_side)
+             
           FED_max_Door(i) = max_fed
           K_ave_Door(i) = ave_K
           IF (FED_DOOR_CRIT < TWO_EPSILON_EB) THEN

--- a/Source/main.f90
+++ b/Source/main.f90
@@ -3246,7 +3246,7 @@ SUBROUTINE EVAC_MAIN_LOOP
 
 ! Call the evacuation routine and adjust the time steps for the evacuation meshes
 
-REAL(EB) :: T_FIRE, EVAC_DT
+REAL(EB) :: T_FIRE, EVAC_DT, DT_TMP
 INTEGER :: II
 
 EVACUATION_SKIP=.FALSE. ! Do not skip the flow calculation
@@ -3260,7 +3260,10 @@ IF (ICYC == 1) DT = DT_EVAC ! Initial fire dt that was read in
 IF (ICYC == 1) T  = T_BEGIN ! Initial fire t  that was read in
 IF (ICYC == 1) T_EVAC = T_BEGIN - 0.1_EB*MIN(EVAC_DT_FLOWFIELD,EVAC_DT_STEADY_STATE)
 IF (ICYC > 0) T_FIRE  = T
-IF (ICYC > 0) EVAC_DT = DT
+
+DT_TMP = DT
+IF ((T+DT)>=T_END) DT_TMP = MAX(MIN(EVAC_DT_STEADY_STATE,T_END-T_EVAC)1,1.E-10_EB)
+IF (ICYC > 0) EVAC_DT = DT_TMP
 
 DO NM = 1, NMESHES
    IF (EVACUATION_ONLY(NM).AND.EMESH_INDEX(NM)==0) EVACUATION_SKIP(NM) = .TRUE.
@@ -3311,7 +3314,7 @@ EVAC_TIME_STEP_LOOP: DO WHILE (T_EVAC < T_FIRE)
             MESHES(NM)%IMN = 0; MESHES(NM)%JMN = 0; MESHES(NM)%KMN = 0
          END IF
          IF (EMESH_INDEX(NM)>0) THEN
-            IF (PROCESS(NM)==MYID .AND. STOP_STATUS==NO_STOP) CALL EVACUATE_HUMANS(T_EVAC,DT,NM,ICYC)
+            IF (PROCESS(NM)==MYID .AND. STOP_STATUS==NO_STOP) CALL EVACUATE_HUMANS(T_EVAC,DT_TMP,NM,ICYC)
             IF (T_EVAC >= PART_CLOCK(NM)) THEN
                IF (PROCESS(NM)==MYID) CALL DUMP_EVAC(T_EVAC, NM)
                DO


### PR DESCRIPTION
Some small bugs corrected in evac.f90. The version is now 2.5.2
due to these bug fixes. No other changes in the algorithms etc.
So, the results of version 2.5.2 should be the same as version
2.5.1, if the bug corrections do not affect the calculation. The
bug fixes were minor fixes for the "see_door" and "see_each_other"
and similar things. Nothing was changed in the "main movement
algorithms".

Also the main.f90 was modified in the evac_main_loop so that
it works now at the last fire time step (Kevin(?) made a change
in the last time step in the main time loop and now also
evacuation time loop does this).
