### PR TITLE
fds+evac: A small correction (error message corrected)

### DIFF
--- a/Source/evac.f90
+++ b/Source/evac.f90
@@ -11036,7 +11036,7 @@ CONTAINS
                JJ_NOW = EVAC_EXITS(N)%I_EMESH_EXITS
                IF (TRIM(EVAC_EXITS(N)%ID) /= TRIM(EMESH_EXITS(JJ_NOW)%ID)) THEN
                   write(lu_err,*)'*** ERROR IN FIND_PREFERRED_DIRECTION'
-                  write(lu_err,*)'*** ',TRIM(EVAC_DOORS(N)%ID), ' is not ',TRIM(EMESH_EXITS(JJ_NOW)%ID)
+                  write(lu_err,*)'*** ',TRIM(EVAC_EXITS(N)%ID), ' is not ',TRIM(EMESH_EXITS(JJ_NOW)%ID)
                END IF
             ELSE
                JJ_NOW = EVAC_DOORS(N)%I_EMESH_EXITS


### PR DESCRIPTION
Small changes in evac.f90. Some error message were corrected (SpringTiger
had found some misleading error messages, e.g., door => exit changes needed.)

I have used this version to calculate my V&V evacuation cases and they seem
to be nice. I have updated the FDS+Evac manual (PDF on the VTT web pages)
using these results.
