### PR TITLE
FDS Validation: mods to Purdue flame input files to break symmetry

### DIFF
--- a/Validation/Purdue_Flames/FDS_Input_Files/7p1_cm_methane_4mm.fds
+++ b/Validation/Purdue_Flames/FDS_Input_Files/7p1_cm_methane_4mm.fds
@@ -36,7 +36,10 @@
 &VENT MB='YMAX', SURF_ID='OPEN'/
 &VENT MB='ZMAX', SURF_ID='OPEN'/
 
-! synthetic turbulence to break symmetry
+&SURF ID='symmetry break', COLOR='BLACK'/
+&OBST XB=.092,.096,.040,.044,0,.004, SURF_ID='symmetry break'/
+
+! add synthetic turbulence to break symmetry
 &VENT XB=-.0355,.0355,-.0355,.0355,0,0
       XYZ=0,0,0, RADIUS=0.0355, SPREAD_RATE=1000
       SURF_ID='FLAME', N_EDDY=100, L_EDDY=0.01775, VEL_RMS=0.003 /

--- a/Validation/Purdue_Flames/FDS_Input_Files/7p1_cm_methane_4mm_16mesh.fds
+++ b/Validation/Purdue_Flames/FDS_Input_Files/7p1_cm_methane_4mm_16mesh.fds
@@ -1,9 +1,9 @@
-&HEAD CHID='7p1_cm_methane_2mm_16mesh', TITLE='Purdue 7.1 cm methane burner' / Y. Xin et al. Combustion and Flame 141 (2005) 329-335
+&HEAD CHID='7p1_cm_methane_4mm_16mesh', TITLE='Purdue 7.1 cm methane burner' / Y. Xin et al. Combustion and Flame 141 (2005) 329-335
 
 MESH IJK=50,50,100, XB=-.1,.1,-.1,.1,0,0.4 / 4 mm single mesh
 
 &MULT ID='mesh array', DX=.1,DY=.1,DZ=.1, I_UPPER=1,J_UPPER=1,K_UPPER=3 /
-&MESH IJK=50,50,50, XB=-.1,0,-.1,0,0,.1, MULT_ID='mesh array' / 2 mm 16 mesh
+&MESH IJK=25,25,25, XB=-.1,0,-.1,0,0,.1, MULT_ID='mesh array' / 4 mm 16 mesh
 
 &TIME T_END=20/
 

--- a/Validation/Purdue_Flames/Run_All.sh
+++ b/Validation/Purdue_Flames/Run_All.sh
@@ -6,6 +6,7 @@ export SVNROOT=`pwd`/../..
 source $SVNROOT/Validation/Common_Run_All.sh
 
 $QFDS $DEBUG       $QUEUE -d $INDIR 7p1_cm_methane_4mm.fds
+$QFDS $DEBUG -p 16 $QUEUE -d $INDIR 7p1_cm_methane_4mm_16mesh.fds
 $QFDS $DEBUG -p 16 $QUEUE -d $INDIR 7p1_cm_methane_2mm_16mesh.fds
 
 echo FDS cases submitted


### PR DESCRIPTION
Still trying ideas to break the symmetry for high resolution case.  I am convinced that this is the only real reason we see inaccuracies in our validation---no way the actual experiment was as symmetric in the lab.