### PR TITLE
Directory structure post-reorg (for review?)

### DIFF
--- a/Build/Scripts/clean.sh
+++ b/Build/Scripts/clean.sh
@@ -5,5 +5,5 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR/../..
 GITROOT=`pwd`
 
-cd $GITROOT/fds/Build/$dir
+cd $GITROOT/Build/$dir
 rm -f *.o *.mod


### PR DESCRIPTION
I needed to alter this portion of hard coded directory as clean.sh was looking in <myGitLocation>/fds/fds/Build/

Changes directory as $GITROOT includes /fds/ hence there is an extra /fds/ when cleaning.