### PR TITLE
manuals: update doc secretary and nist directory names for manual cov…

### DIFF
--- a/Manuals/Bibliography/commoncommands.tex
+++ b/Manuals/Bibliography/commoncommands.tex
@@ -190,10 +190,10 @@ Austin, Texas, USA}
 \small
 \begin{flushright}
 U.S. Department of Commerce \\
-{\em Penny Pritzker, Secretary} \\
+{\em Wilbur L. Ross, Jr., Secretary} \\
 \hspace{1in} \\
 National Institute of Standards and Technology \\
-{\em Willie May, Under Secretary of Commerce for Standards and Technology and Director}
+{\em Kent Rochford, Acting Under Secretary of Commerce for Standards and Technology and Acting NIST Director}
 \end{flushright}
 }
 


### PR DESCRIPTION
…er pages

am working on my manuals and updated  names on the cover page.  I got the info from

https://www.commerce.gov/ for doc secretary name and https://www.nist.gov/director for nist director name.  I'll let you accept the pull request (instead of me) if you agree with my edits.
