### PR TITLE
edit make_linux/intel fds.sh scripts 

### DIFF
--- a/Build/intel_linux_64/make_fds.sh
+++ b/Build/intel_linux_64/make_fds.sh
@@ -3,7 +3,9 @@ platform=intel64
 dir=`pwd`
 target=${dir##*/}
 
+if [ "$IFORT_COMPILER" != "" ]; then
 source $IFORT_COMPILER/bin/compilervars.sh $platform
+fi
 
 echo Building $target
 make VPATH="../../Source" -f ../makefile $target

--- a/Build/intel_linux_64_db/make_fds.sh
+++ b/Build/intel_linux_64_db/make_fds.sh
@@ -3,7 +3,9 @@ platform=intel64
 dir=`pwd`
 target=${dir##*/}
 
+if [ "$IFORT_COMPILER" != "" ];  then
 source $IFORT_COMPILER/bin/compilervars.sh $platform
+fi
 
 echo Building $target
 make -j4 VPATH="../../Source" -f ../makefile $target

--- a/Build/intel_linux_64_dv/make_fds.sh
+++ b/Build/intel_linux_64_dv/make_fds.sh
@@ -3,7 +3,9 @@ platform=intel64
 dir=`pwd`
 target=${dir##*/}
 
+if [ "$IFORT_COMPILER" != "" ]; then
 source $IFORT_COMPILER/bin/compilervars.sh $platform
+fi
 
 echo Building $target
 make -j4 VPATH="../../Source" -f ../makefile $target

--- a/Build/mpi_intel_linux_64/make_fds.sh
+++ b/Build/mpi_intel_linux_64/make_fds.sh
@@ -4,7 +4,9 @@ platform=intel64
 dir=`pwd`
 target=${dir##*/}
 
+if [ "$IFORT_COMPILER" != "" ]; then
 source $IFORT_COMPILER/bin/compilervars.sh $platform
+fi
 source ../Scripts/set_mpidist.sh eth $MPIDIST_ETH
 
 if [ "$MPIDIST" == "" ]; then

--- a/Build/mpi_intel_linux_64_db/make_fds.sh
+++ b/Build/mpi_intel_linux_64_db/make_fds.sh
@@ -3,7 +3,9 @@ platform=intel64
 dir=`pwd`
 target=${dir##*/}
 
+if [ "$IFORT_COMPILER" != "" ]; then
 source $IFORT_COMPILER/bin/compilervars.sh $platform
+fi
 source ../Scripts/set_mpidist.sh eth $MPIDIST_ETH
 if [ "$MPIDIST" == "" ]; then
   exit

--- a/Build/mpi_intel_linux_64ib/make_fds.sh
+++ b/Build/mpi_intel_linux_64ib/make_fds.sh
@@ -3,7 +3,9 @@ platform=intel64
 dir=`pwd`
 target=${dir##*/}
 
+if [ "$IFORT_COMPILER" != "" ]; then
 source $IFORT_COMPILER/bin/compilervars.sh $platform
+fi
 source ../Scripts/set_mpidist.sh ib $MPIDIST_IB
 if [ "$MPIDIST" == "" ]; then
 # if MPIDIST was not defined above, abort

--- a/Build/mpi_intel_linux_64ib_db/make_fds.sh
+++ b/Build/mpi_intel_linux_64ib_db/make_fds.sh
@@ -3,7 +3,9 @@ platform=intel64
 dir=`pwd`
 target=${dir##*/}
 
+if [ "$IFORT_COMPILER" != "" ] then
 source $IFORT_COMPILER/bin/compilervars.sh $platform
+fi
 source ../Scripts/set_mpidist.sh ib $MPIDIST_IB
 if [ "$MPIDIST" == "" ]; then
 # if MPIDIST was not defined above, abort

--- a/Build/mpi_intel_linux_64ib_dv/make_fds.sh
+++ b/Build/mpi_intel_linux_64ib_dv/make_fds.sh
@@ -3,7 +3,9 @@ platform=intel64
 dir=`pwd`
 target=${dir##*/}
 
+if [ "$IFORT_COMPILER" != "" ]; then
 source $IFORT_COMPILER/bin/compilervars.sh $platform
+fi
 source ../Scripts/set_mpidist.sh ib $MPIDIST_IB
 if [ "$MPIDIST" == "" ]; then
 # if MPIDIST was not defined above, abort


### PR DESCRIPTION
on some systems IFORT_COMPILER is needed in the make_fds.sh  scripts (so on these systems you would remove it).  So we now check to see if the environment variable exists before sourcing $IFORT_COMPILER/... in intel/linux make_fds.sh  scripts.

randy - you should not need to edit make_fds.sh on hercules2 now as long as you remove IFORT_COMPILER definiton from your .bashrc file