### PR TITLE
scripts: add a script to archive an FDS case

### DIFF
--- a/Utilities/Scripts/copycase.sh
+++ b/Utilities/Scripts/copycase.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+if [ $# -lt 1 ]; then
+  echo "Usage: copycase.sh casename [HOST]"
+  echo ""
+  echo "The script copycase.sh creates a tar file for the FDS case with CHID"
+  echo "casename (excluding the restart files).  The parameter HOST is optional."
+  echo "If HOST is present it will copy the tar file to that host (for example"
+  echo "blaze.el.nist.gov). If the parameter HOST is not present it will copy"
+  echo "the tar file to the directory $HOME/TARCASES"
+  exit
+fi
+CHID=$1
+HOST=$2
+TARDIR=$HOME/TARCASES
+TARFILE=$TARDIR/${CHID}.tar
+if [ ! -d $TARDIR ]; then
+  mkdir $TARDIR
+fi
+tar -cvf $TARFILE --exclude='./*.restart' ./${CHID}*
+if [ "$HOST" == "" ]; then
+echo
+echo FDS case: $CHID 
+echo copied to: $TARFILE
+else
+scp -q $TARFILE $HOST\:.
+echo FDS case: $CHID 
+echo copied to host $HOST at ${CHID}.tar
+fi


### PR DESCRIPTION
This script makes it easy to copy a case from one computer to another.  To use it cd to the directory where the case is and type

copycase.sh casename

This will create a tar file of all files that match casename* (except for casename*.restart ).  If you add a hostname for a second parameter as in

copycase.sh casename  hostname

the script will tar up the FDS case before and also copy the .tar file to the computer hostname . 