### PR TITLE
Update FDS_User_Guide

### DIFF
--- a/Manuals/FDS_User_Guide/FDS_User_Guide.tex
+++ b/Manuals/FDS_User_Guide/FDS_User_Guide.tex
@@ -3007,7 +3007,7 @@ value of heat of combustion can be specified for each reaction, $j$, via the par
 
 \subsubsection{Modeling Upholstered Furnishings}
 
-The example input files called {\ct Fires/couch.fds} and {\ct Fires/room\_fire.fds} demonstrate a simple way to model upholstered furniture. In residential fires, upholstered furniture makes up a significant fraction of the combustible load. A single couch can generate several megawatts of energy and sometimes lead to compartment flashover. Modeling a couch fire requires a simplification of its structure and materials.  At the very least, we want the upholstery to be modeled as a layer of fabric covering polyurethane foam. We need the thermal properties of each, along with estimates of the ``reference'' temperatures as described above. The foam might be described as follows:
+The example input file called {\ct Fires/couch.fds} demonstrates a simple way to model upholstered furniture. In residential fires, upholstered furniture makes up a significant fraction of the combustible load. A single couch can generate several megawatts of energy and sometimes lead to compartment flashover. Modeling a couch fire requires a simplification of its structure and materials.  At the very least, we want the upholstery to be modeled as a layer of fabric covering polyurethane foam. We need the thermal properties of each, along with estimates of the ``reference'' temperatures as described above. The foam might be described as follows:
 \begin{lstlisting}
 &MATL ID                    = 'FOAM'
       SPECIFIC_HEAT         = 1.0


### PR DESCRIPTION
Removing room_fire.fds from the text. See \subsubsection{Modeling Upholstered Furnishings}
I wonder why this file was taken away from the files. I still remember it was in version 6.
If it was by mistake, then reject this request and the file should be added to the Fire directory.