### PR TITLE
FDS Source : Add routine SET_CFACES_ONE_D_RDN to set CFACES(ICF)%ONE_D%RDN.

### DIFF
--- a/Source/geom.f90
+++ b/Source/geom.f90
@@ -1793,7 +1793,7 @@ MESH_LOOP_1 : DO NM=LOWER_MESH_INDEX,UPPER_MESH_INDEX
                   I = CUT_CELL(ICC)%IJK(IAXIS)
                   J = CUT_CELL(ICC)%IJK(JAXIS)
                   K = CUT_CELL(ICC)%IJK(KAXIS)
-                  DCFXN2 = 0.5_EB*(NVEC(IAXIS)*DX(I)+NVEC(JAXIS)*DY(J)+NVEC(KAXIS)*DZ(K))
+                  DCFXN2 = 0.5_EB*ABS(NVEC(IAXIS)*DX(I)+NVEC(JAXIS)*DY(J)+NVEC(KAXIS)*DZ(K))
                   WRITE(LU_ERR,*) 'Dist from CC to INB cut-face < GEOMEPS=',ICF,IFACE,DCFXN,'Will use 1/2*dot(DX,n)=',DCFXN2
                   DCFXN = DCFXN2
                ENDIF


### PR DESCRIPTION
This routine is called from the setup routine CCIBM_SET_DATA.
The computation of RDN=1/DCFN for each boundary cut-face in CFACE is done in the sequence:
- DCFN = 2*|dot(**Xc**-**Xf**,**nf**)|, where **Xc** is the location of the connected cut-cell centroid, **Xf** is the centroid location for the cut-face, and **nf** is the normal unit vector to the cut-face.
- If this value is smaller that GEOMEPS tolerance, the value DCFN = 2*|**Xc**-**Xf**| is tested.
- If the previous is still not in tolerance, DCFN = |dot(**DX**,**nf**)| is used. Here, **DX**=(dx,dy,dz) of the under-laying cartesian cell.
This is done to maintain robustness, albeit at the accuracy cost on evaluating diffusive fluxes in the boundary face.
