### PR TITLE
Add CSVF entries to smokeview file for ctrl and mass.

### DIFF
--- a/Source/dump.f90
+++ b/Source/dump.f90
@@ -1391,6 +1391,18 @@ DO I=1,N_DEVC_FILES
    WRITE(LU_SMV,'(1X,A)') TRIM(FN_DEVC(I))
 ENDDO
 
+DO I=1,N_CTRL_FILES
+   WRITE(LU_SMV,'(/A)') 'CSVF'
+   WRITE(LU_SMV,'(1X,A)') 'ctrl'
+   WRITE(LU_SMV,'(1X,A)') TRIM(FN_CTRL(I))
+ENDDO
+
+IF (MASS_FILE) THEN
+   WRITE(LU_SMV,'(/A)') 'CSVF'
+   WRITE(LU_SMV,'(1X,A)') 'mass'
+   WRITE(LU_SMV,'(1X,A)') TRIM(FN_MASS)
+ENDIF
+
 ! Write out file names specified using CSVF
 
 DO N = 1, N_CSVF


### PR DESCRIPTION
Smokeview files contain entries for the location of hrr.csv and devc.csv files but not ctrl.csv or mass.csv. This adds these entries.

Smokeview ignores CSVF entries it doesn't recognise so this doesn't affect smokeview reading the .smv file.