### PR TITLE
Update character limit text for TITLE and CHID.

### DIFF
--- a/Manuals/FDS_User_Guide/FDS_User_Guide.tex
+++ b/Manuals/FDS_User_Guide/FDS_User_Guide.tex
@@ -939,8 +939,8 @@ two parameters, as in this example:
 &HEAD CHID='WTC_05', TITLE='WTC Phase 1, Test 5' /
 \end{lstlisting}
 \begin{description}
-\item {\ct CHID} is a string of 30 characters or less used to tag the output files. If, for example, {\ct CHID='WTC\_05'}, it is convenient to name the input data file {\ct WTC\_05.fds} so that the input file can be associated with the output files. No periods or spaces are allowed in {\ct CHID} because the output files are tagged with suffixes that are meaningful to certain computer operating systems.  If {\ct CHID} is not specified, then it will be set to the name of the input file minus everything at and beyond the first period.
-\item {\ct TITLE} is a string of 60 characters or less that describes the simulation. It is simply a descriptive text that is passed to various output files.
+\item {\ct CHID} is a string of 40 characters or less used to tag the output files. If, for example, {\ct CHID='WTC\_05'}, it is convenient to name the input data file {\ct WTC\_05.fds} so that the input file can be associated with the output files. No periods or spaces are allowed in {\ct CHID} because the output files are tagged with suffixes that are meaningful to certain computer operating systems.  If {\ct CHID} is not specified, then it will be set to the name of the input file minus everything at and beyond the first period.
+\item {\ct TITLE} is a string of 256 characters or less that describes the simulation. It is simply a descriptive text that is passed to various output files.
 \end{description}
 
 


### PR DESCRIPTION
TITLE is defined with a 256 character limit.
https://github.com/firemodels/fds/blob/master/Source/cons.f90#L100

In cons.f90 CHID is defined with a 40 character limit. 
https://github.com/firemodels/fds/blob/master/Source/cons.f90#L101

This update changes the text in the User Manual to match the source.