### PR TITLE
Update test_mpi_openmpi/Makefile

### DIFF
--- a/Utilities/test_mpi_openmp/makefile
+++ b/Utilities/test_mpi_openmp/makefile
@@ -33,18 +33,18 @@ openmp_impi_intel_win: obj = test_mpi_openmp
 openmp_impi_intel_win: setup_win $(objwin_mpi)
 	$(FCOMPL) -o $(obj) $(FFLAGS) /F1000000000 $(objwin_mpi) $(MPILIB)
 
-openmp_impi_intel_linux : FFLAGS = -m64 -O2 -openmp
+openmp_impi_intel_linux : FFLAGS = -m64 -O2 -qopenmp
 openmp_impi_intel_linux : LFLAGS = -static-intel
 openmp_impi_intel_linux : FCOMPL = mpiifort
-openmp_impi_intel_linux : FOPENMPFLAGS = -openmp-link static -liomp5 
+openmp_impi_intel_linux : FOPENMPFLAGS = -qopenmp-link static -liomp5 
 openmp_impi_intel_linux : obj = test_mpi_openmp
 openmp_impi_intel_linux : setup $(obj_mpi)
 	$(FCOMPL) $(FFLAGS) $(LFLAGS) $(FOPENMPFLAGS) -o $(obj) $(obj_mpi)
 
-openmp_mpi_intel_linux : FFLAGS = -m64 -O2 -openmp
+openmp_mpi_intel_linux : FFLAGS = -m64 -O2 -qopenmp
 openmp_mpi_intel_linux : LFLAGS = -static-intel
 openmp_mpi_intel_linux : FCOMPL = mpifort
-openmp_mpi_intel_linux : FOPENMPFLAGS = -openmp-link static -liomp5
+openmp_mpi_intel_linux : FOPENMPFLAGS = -qopenmp-link static -liomp5
 openmp_mpi_intel_linux : obj = test_mpi_openmp
 openmp_mpi_intel_linux : setup $(obj_mpi)
 	$(FCOMPL) $(FFLAGS) $(LFLAGS) $(FOPENMPFLAGS) -o $(obj) $(obj_mpi)


### PR DESCRIPTION
Update openmp flag. Intel is moving from -openm to -qopenm in the coming releases.