### PR TITLE
update bundle script

### DIFF
--- a/Utilities/Scripts/BUNDLE_linux64.sh
+++ b/Utilities/Scripts/BUNDLE_linux64.sh
@@ -3,7 +3,6 @@
 # this script is called from windows which passes in the directory 
 # containing this script
 #
-INTEL_VERSION=17
 
 export fds_smvroot=$1
 export bundlebase=$2
@@ -21,6 +20,6 @@ export MISCFROM=$9
 export FDSOS=_linux_64
 export INSTALLDIR=FDS/$FDSEDITION
 export MISCTO=LIB64
-export COMPTO=INTELLIBS$INTEL_VERSION
+export COMPTO=INTELLIBS
 
 $fds_smvroot/fds/Utilities/Scripts/bundle_generic.sh

--- a/Utilities/Scripts/for_bundle/startup_template
+++ b/Utilities/Scripts/for_bundle/startup_template
@@ -1,20 +1,25 @@
 # notes:
-# 1.  should only need "part 0" and "part 1" if a user is using the repo and does not have fds installed
-# 2.  should only need "part 0" and "part 2" if a user is using the installed fds and is not using the repo
-# 3.  except that INTEL_SHARED_LIB for installed fds may not be compatible with INTEL_SHARED_LIB
-#     needed for installed bundle fds.  The solution is to set this variable when running qfds.sh .
-#     The parameter #PBS -v seems to be the way to do this but I have not been able to get this to work.
-# 4.  The variables MPIDIST_ETH, MPIDST_IB and MPIDIST are necessary until I figure out how to 
-#     run fds on ethernet hardware using an infiniband openmpi
+# 1.  should only need "part 0" and "part 1" if a user is using the repo 
+#     and does not have fds installed
+# 2.  should only need "part 0" and "part 2" if a user is using the installed
+#     fds and is not using the repo
+# 3.  except that INTEL_SHARED_LIB for installed fds may not be compatible 
+#     with INTEL_SHARED_LIB needed for installed bundle fds.  The solution is
+#     to set this variable when running qfds.sh . The parameter #PBS -v seems
+#     to be the way to do this but I have not been able to get this to work.
+# 4.  The variables MPIDIST_ETH, MPIDST_IB and MPIDIST are necessary until 
+#     I figure out how to run fds on ethernet hardware using an infiniband
+#     openmpi
 #
 
 # to do:
-# add the following commands to your startup file and customize for your environment
-# try using just part 0 and part 1 to build and run repo fds then repeat using just part 0 
-# and part 2 to run installed fds
+# add the following commands to your startup file and customize for your 
+# environment try using just part 0 and part 1 to build and run repo fds 
+# then repeat using just part 0 and part 1 to build and run repo fds then 
+# repeat using just part 0
 #
-# Let me know if you see any problems.  I've edited this file since I've tested it so there errors
-# may have crept in.
+# Let me know if you see any problems.  I've edited this file since I've 
+# tested it so there errors may have crept in
 
 #-------- part 0--------------------------------------
 # variable needed for both installed fds and repo fds
@@ -28,6 +33,10 @@ export MPIDIST=$MPIDIST_IB
 # variables needed by qfds.sh when running fds
 export FDSNETWORK=infiniband
 export PATH=$PATH:$MPIDIST/bin
+
+# set stack size
+
+ulimit -s ulimited
 
 #-------- part 1--------------------------------------
 # variable needed when building or running a repo fds

--- a/Utilities/Scripts/for_bundle/startup_template
+++ b/Utilities/Scripts/for_bundle/startup_template
@@ -52,6 +52,10 @@ export FDSBINDIR=$HOME/FDS/FDS6/bin
 # (comment if using repo fds)
 #INTEL_SHARED_LIB=$FDSBINDIR/INTELLIBS16
 
+# Set number of OMP threads
+#
+export OMP_NUM_THREADS=4
+
 export LD_LIBRARY_PATH=$INTEL_SHARED_LIB:$LD_LIBRARY_PATH
 export PATH=$PATH:$FDSBINDIR
 #-----------------------------------------------------

--- a/Utilities/Scripts/for_bundle/startup_template
+++ b/Utilities/Scripts/for_bundle/startup_template
@@ -1,36 +1,56 @@
-# add the following commands to your startup file and customize for your environment
+# notes:
+# 1.  should only need "part 0" and "part 1" if a user is using the repo and does not have fds installed
+# 2.  should only need "part 0" and "part 2" if a user is using the installed fds and is not using the repo
+# 3.  except that INTEL_SHARED_LIB for installed fds may not be compatible with INTEL_SHARED_LIB
+#     needed for installed bundle fds.  The solution is to set this variable when running qfds.sh .
+#     The parameter #PBS -v seems to be the way to do this but I have not been able to get this to work.
+# 4.  The variables MPIDIST_ETH, MPIDST_IB and MPIDIST are necessary until I figure out how to 
+#     run fds on ethernet hardware using an infiniband openmpi
+#
 
-# -----------------------------------------------------
+# to do:
+# add the following commands to your startup file and customize for your environment
+# try using just part 0 and part 1 to build and run repo fds then repeat using just part 0 
+# and part 2 to run installed fds
+#
+# Let me know if you see any problems.  I've edited this file since I've tested it so there errors
+# may have crept in.
+
+#-------- part 0--------------------------------------
+# variable needed for both installed fds and repo fds
+
+# mpi library locations
+export MPIDIST_ETH=/shared/openmpi_64
+export MPIDIST_IB=/shared/openmpi_64ib
+
+export MPIDIST=$MPIDIST_IB
+
+# variables needed by qfds.sh when running fds
+export FDSNETWORK=infiniband
+export PATH=$PATH:$MPIDIST/bin
+
+#-------- part 1--------------------------------------
 # variable needed when building or running a repo fds
 
 # compiler location
 export IFORT_COMPILER=/opt/intel17
 export IFORT_COMPILER_LIB=$IFORT_COMPILER/lib
 
-# mpi library locations
-export MPIDIST_ETH=/shared/openmpi_64
-export MPIDIST_IB=/shared/openmpi_64ib
-
-# variables needed by qfds.sh when running fds
-export FDSNETWORK=infiniband
-export MPIDIST=$MPIDIST_IB
-
 # Intel shared compiler libraries needed when running repo built fds
 # (comment if using intalled FDS)
 INTEL_SHARED_LIB=$IFORT_COMPILER_LIB/intel64
 
 export LD_LIBRARY_PATH=/usr/lib64:$INTEL_SHARED_LIB:$LD_LIBRARY_PATH
-export PATH=$PATH:$MPIDIST/bin
 
-#-----------------------------------------------------
-# variables needed for installed fds
+#-------- part 2--------------------------------------
+# variables needed when running an installed fds
 
 # fds location
 export FDSBINDIR=$HOME/FDS/FDS6/bin
 
 # Intel shared compiler libraries needed when installed fds
 # (comment if using repo fds)
-INTEL_SHARED_LIB=$FDSBINDIR/INTELLIBS16
+#INTEL_SHARED_LIB=$FDSBINDIR/INTELLIBS16
 
 export LD_LIBRARY_PATH=$INTEL_SHARED_LIB:$LD_LIBRARY_PATH
 export PATH=$PATH:$FDSBINDIR

--- a/Utilities/Scripts/make_installer.sh
+++ b/Utilities/Scripts/make_installer.sh
@@ -481,17 +481,8 @@ export PATH=\\\$FDSBINDIR:\\\$PATH
 
 export OMP_NUM_THREADS=4
 BASH
-if [ "$ostype" == "OSX" ]; then
-cat << BASH >> \$BASHRCFDS
-ulimit -s 65532
-BASH
-else
-cat << BASH >> \$BASHRCFDS
-ulimit -s unlimited
-BASH
-fi
 
-#--- creat
+#--- create startup file for FDS
 
 cp \$BASHRCFDS \$FDS_root/bin/FDSVARS.sh
 chmod +x \$FDS_root/bin/FDSVARS.sh


### PR DESCRIPTION
simplify the fds installer script requiring user to put prerequisites (mpi library locations, updating path etc) in their startup file .  The user's startup files are no longer modified by the installer