### PR TITLE
Update box_burn_away_2D_residue.fds

### DIFF
--- a/Verification/Fires/box_burn_away_2D_residue.fds
+++ b/Verification/Fires/box_burn_away_2D_residue.fds
@@ -1,10 +1,10 @@
 &HEAD CHID='box_burn_away_2D_residue', TITLE='Test BURN_AWAY feature' / 
 
 The FOAM box is evaporated away by the high thermal radiation
-from HOT surfaces. The mass of the box is 1 * 0.4^2 m3 * 20 kg/m3 = 3.2 kg.
+from HOT surfaces. The mass of the box is 0.4^3 m3 * 20 kg/m3 = 1.28 kg.
 Half of the mass is converted to fuel and other half to residue.
 Bulk density defines the combustible mass of the box:
-     10 kg/m3 x 0.16 m3 = 1.6 kg.
+     10 kg/m3 x 0.064 m3 = 0.64 kg.
 This should be compared to the final value of fuel density volume integral, 
 computed by the first DEVC.
 


### PR DESCRIPTION
Correct the mass of the box.  Even though the box is set to 1 m, however the domain is only 0.4 m, where .6 m will be ignored. Therefore, the actual mass that will be compared is within the domain, i.e. 0.4. Hence the total mass is 1.28 kg and 0.64kg for residue as found in the Devc file, or by integrating the MLR area.