### PR TITLE
Update box_burn_away_2D.fds

### DIFF
--- a/Verification/Fires/box_burn_away_2D.fds
+++ b/Verification/Fires/box_burn_away_2D.fds
@@ -1,7 +1,7 @@
 &HEAD CHID='box_burn_away_2D', TITLE='Test BURN_AWAY feature' / 
 
 The FOAM box is evaporated away by the high thermal radiation
-from HOT surfaces. The mass of the box is 1 * 0.4^2 m3 * 20 kg/m3 = 3.2 kg.
+from HOT surfaces. The mass of the box is 0.4^3 m3 * 20 kg/m3 = 1.28 kg.
 This should be compared to the final value of fuel density volume integral, 
 computed by the first DEVC.
 


### PR DESCRIPTION
Correct the mass of the box.  Even though the box is set to 1 m, however the domain is only 0.4 m, where .6 m will be ignored. Therefore, the actual mass that will be compared is within the domain, i.e. 0.4. Hence the total mass is 1.28 kg as found in the Devc file, or by integrating the MLR area.