### PR TITLE
add option to qfds.sh to specify a module, add some modules for older intel compilers

### DIFF
--- a/Utilities/Scripts/for_bundle/Modules/linux/intel/15
+++ b/Utilities/Scripts/for_bundle/Modules/linux/intel/15
@@ -1,0 +1,62 @@
+#%Module####################################
+
+# put name of module here
+
+
+module-whatis   "brief description of this module"
+
+proc ModulesHelp { } {
+        puts stderr "no so brief information"
+        puts stderr "about this module"
+}
+
+setenv IFORT_COMPILER_LIB /opt/intel/lib/intel64
+prepend-path CPATH /opt/intel/composer_xe_2015.2.164/tbb/include
+prepend-path CPATH /opt/intel/composer_xe_2015.2.164/mkl/include
+prepend-path CPATH /opt/intel/composer_xe_2015.2.164/ipp/include
+setenv GDB_CROSS /opt/intel/composer_xe_2015.2.164/debugger/gdb/intel64_mic/bin/gdb-mic
+setenv GDB_HOST /opt/intel/composer_xe_2015.2.164/debugger/gdb/intel64_mic/bin/gdb-ia-mic
+setenv GDBSERVER_MIC /opt/intel/composer_xe_2015.2.164/debugger/gdb/target/mic/bin/gdbserver
+setenv INCLUDE /opt/intel/composer_xe_2015.2.164/mkl/include
+prepend-path INFOPATH /opt/intel/composer_xe_2015.2.164/debugger/gdb/intel64_mic/share/info/
+prepend-path INFOPATH /opt/intel/composer_xe_2015.2.164/debugger/gdb/intel64/share/info/
+setenv INTEL_LICENSE_FILE /opt/intel/composer_xe_2015.2.164/licenses:/opt/intel/licenses:/home4/gforney/intel/licenses
+setenv INTEL_PYTHONHOME /opt/intel/composer_xe_2015.2.164/debugger/python/intel64/
+setenv IPPROOT /opt/intel/composer_xe_2015.2.164/ipp
+prepend-path LD_LIBRARY_PATH /opt/intel/composer_xe_2015.2.164/debugger/ipt/intel64/lib
+prepend-path LD_LIBRARY_PATH /opt/intel/composer_xe_2015.2.164/tbb/lib/intel64/gcc4.4
+prepend-path LD_LIBRARY_PATH /opt/intel/composer_xe_2015.2.164/mkl/lib/intel64
+prepend-path LD_LIBRARY_PATH /opt/intel/composer_xe_2015.2.164/compiler/lib/intel64
+prepend-path LD_LIBRARY_PATH /opt/intel/composer_xe_2015.2.164/ipp/tools/intel64/perfsys
+prepend-path LD_LIBRARY_PATH /opt/intel/composer_xe_2015.2.164/ipp/lib/intel64
+prepend-path LD_LIBRARY_PATH /opt/intel/composer_xe_2015.2.164/ipp/../compiler/lib/intel64
+prepend-path LD_LIBRARY_PATH /opt/intel/composer_xe_2015.2.164/mpirt/lib/intel64
+prepend-path LD_LIBRARY_PATH /opt/intel/composer_xe_2015.2.164/compiler/lib/intel64
+prepend-path LIBRARY_PATH /opt/intel/composer_xe_2015.2.164/tbb/lib/intel64/gcc4.4
+prepend-path LIBRARY_PATH /opt/intel/composer_xe_2015.2.164/mkl/lib/intel64
+prepend-path LIBRARY_PATH /opt/intel/composer_xe_2015.2.164/compiler/lib/intel64
+prepend-path LIBRARY_PATH /opt/intel/composer_xe_2015.2.164/ipp/lib/intel64
+prepend-path LIBRARY_PATH /opt/intel/composer_xe_2015.2.164/ipp/../compiler/lib/intel64
+prepend-path LIBRARY_PATH /opt/intel/composer_xe_2015.2.164/compiler/lib/intel64
+prepend-path MANPATH /opt/intel/composer_xe_2015.2.164/debugger/gdb/intel64_mic/share/man/
+prepend-path MANPATH /opt/intel/composer_xe_2015.2.164/debugger/gdb/intel64/share/man/
+prepend-path MANPATH /opt/intel/composer_xe_2015.2.164/man/en_US
+prepend-path MANPATH /opt/intel/composer_xe_2015.2.164/man/en_US
+prepend-path MIC_LD_LIBRARY_PATH /opt/intel/composer_xe_2015.2.164/tbb/lib/mic
+prepend-path MIC_LD_LIBRARY_PATH /opt/intel/composer_xe_2015.2.164/mkl/lib/mic
+prepend-path MIC_LD_LIBRARY_PATH /opt/intel/composer_xe_2015.2.164/compiler/lib/mic
+prepend-path MIC_LD_LIBRARY_PATH /opt/intel/composer_xe_2015.2.164/mpirt/lib/mic
+prepend-path MIC_LD_LIBRARY_PATH /opt/intel/composer_xe_2015.2.164/compiler/lib/mic
+prepend-path MIC_LIBRARY_PATH /opt/intel/composer_xe_2015.2.164/tbb/lib/mic
+prepend-path MIC_LIBRARY_PATH /opt/intel/composer_xe_2015.2.164/mpirt/lib/mic
+prepend-path MIC_LIBRARY_PATH /opt/intel/composer_xe_2015.2.164/compiler/lib/mic
+setenv MKLROOT /opt/intel/composer_xe_2015.2.164/mkl
+setenv MPM_LAUNCHER /opt/intel/composer_xe_2015.2.164/debugger/mpm/bin/start_mpm.sh
+prepend-path NLSPATH /opt/intel/composer_xe_2015.2.164/debugger/gdb/intel64/share/locale/%l_%t/%N
+prepend-path NLSPATH /opt/intel/composer_xe_2015.2.164/debugger/gdb/intel64_mic/share/locale/%l_%t/%N
+prepend-path NLSPATH /opt/intel/composer_xe_2015.2.164/mkl/lib/intel64/locale/%l_%t/%N
+prepend-path NLSPATH /opt/intel/composer_xe_2015.2.164/ipp/lib/intel64/locale/%l_%t/%N
+prepend-path NLSPATH /opt/intel/composer_xe_2015.2.164/compiler/lib/intel64/locale/%l_%t/%N
+prepend-path PATH /opt/intel/composer_xe_2015.2.164/debugger/gdb/intel64_mic/bin
+prepend-path PATH /opt/intel/composer_xe_2015.2.164/bin/intel64
+setenv TBBROOT /opt/intel/composer_xe_2015.2.164/tbb

--- a/Utilities/Scripts/for_bundle/Modules/linux/intel/16
+++ b/Utilities/Scripts/for_bundle/Modules/linux/intel/16
@@ -1,0 +1,71 @@
+#%Module####################################
+
+# put name of module here
+
+
+module-whatis   "brief description of this module"
+
+proc ModulesHelp { } {
+        puts stderr "no so brief information"
+        puts stderr "about this module"
+}
+
+setenv IFORT_COMPILER_LIB /opt/intel16/lib/intel64
+prepend-path CLASSPATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/daal/lib/daal.jar
+prepend-path CPATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/daal/include
+prepend-path CPATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/tbb/include
+prepend-path CPATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/mkl/include
+prepend-path CPATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/ipp/include
+setenv DAALROOT /opt/intel16/compilers_and_libraries_2016.3.210/linux/daal
+setenv GDB_CROSS /opt/intel16/debugger_2016/gdb/intel64_mic/bin/gdb-mic
+setenv GDBSERVER_MIC /opt/intel16/debugger_2016/gdb/targets/mic/bin/gdbserver
+setenv I_MPI_ROOT /opt/intel16/compilers_and_libraries_2016.3.210/linux/mpi
+prepend-path INFOPATH /opt/intel16/documentation_2016/en/debugger//gdb-igfx/info/
+prepend-path INFOPATH /opt/intel16/documentation_2016/en/debugger//gdb-mic/info/
+prepend-path INFOPATH /opt/intel16/documentation_2016/en/debugger//gdb-ia/info/
+setenv INTEL_LICENSE_FILE /opt/intel16/compilers_and_libraries_2016.3.210/linux/licenses:/opt/intel/licenses:/home4/gforney/intel/licenses
+setenv INTEL_PYTHONHOME /opt/intel16/debugger_2016/python/intel64/
+setenv IPPROOT /opt/intel16/compilers_and_libraries_2016.3.210/linux/ipp
+prepend-path LD_LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/daal/../compiler/lib/intel64_lin
+prepend-path LD_LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/daal/../tbb/lib/intel64_lin/gcc4.4
+prepend-path LD_LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/daal/lib/intel64_lin
+prepend-path LD_LIBRARY_PATH /opt/intel16/debugger_2016/libipt/intel64/lib
+prepend-path LD_LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/tbb/lib/intel64/gcc4.4
+prepend-path LD_LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/mkl/lib/intel64
+prepend-path LD_LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/compiler/lib/intel64
+prepend-path LD_LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/ipp/lib/intel64
+prepend-path LD_LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/mpi/mic/lib
+prepend-path LD_LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/mpi/intel64/lib
+prepend-path LD_LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/compiler/lib/intel64_lin
+prepend-path LD_LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/compiler/lib/intel64
+prepend-path LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/daal/../compiler/lib/intel64_lin
+prepend-path LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/daal/../tbb/lib/intel64_lin/gcc4.4
+prepend-path LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/daal/lib/intel64_lin
+prepend-path LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/tbb/lib/intel64/gcc4.4
+prepend-path LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/mkl/lib/intel64
+prepend-path LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/compiler/lib/intel64
+prepend-path LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/ipp/lib/intel64
+prepend-path MANPATH /opt/intel16/documentation_2016/en/debugger//gdb-igfx/man/
+prepend-path MANPATH /opt/intel16/documentation_2016/en/debugger//gdb-mic/man/
+prepend-path MANPATH /opt/intel16/documentation_2016/en/debugger//gdb-ia/man/
+prepend-path MANPATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/mpi/man
+prepend-path MANPATH /opt/intel16/man/common
+prepend-path MIC_LD_LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/tbb/lib/mic
+prepend-path MIC_LD_LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/mkl/lib/mic
+prepend-path MIC_LD_LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/compiler/lib/mic
+prepend-path MIC_LD_LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/ipp/lib/mic
+prepend-path MIC_LD_LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/compiler/lib/mic
+prepend-path MIC_LD_LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/mpi/mic/lib
+prepend-path MIC_LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/tbb/lib/mic
+prepend-path MIC_LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/compiler/lib/mic
+prepend-path MIC_LIBRARY_PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/mpi/mic/lib
+setenv MKLROOT /opt/intel16/compilers_and_libraries_2016.3.210/linux/mkl
+setenv MPM_LAUNCHER /opt/intel16/debugger_2016/mpm/mic/bin/start_mpm.sh
+prepend-path NLSPATH /opt/intel16/debugger_2016/gdb/intel64/share/locale/%l_%t/%N
+prepend-path NLSPATH /opt/intel16/debugger_2016/gdb/intel64_mic/share/locale/%l_%t/%N
+prepend-path NLSPATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/mkl/lib/intel64/locale/%l_%t/%N
+prepend-path NLSPATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/compiler/lib/intel64/locale/%l_%t/%N
+prepend-path PATH /opt/intel16/debugger_2016/gdb/intel64_mic/bin
+prepend-path PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/mpi/intel64/bin
+prepend-path PATH /opt/intel16/compilers_and_libraries_2016.3.210/linux/bin/intel64
+setenv TBBROOT /opt/intel16/compilers_and_libraries_2016.3.210/linux/tbb

--- a/Utilities/Scripts/for_bundle/Modules/linux/intel/17
+++ b/Utilities/Scripts/for_bundle/Modules/linux/intel/17
@@ -1,75 +1,79 @@
-#%Module
+#%Module####################################
+
+# put name of module here
+
+
+module-whatis   "brief description of this module"
 
 proc ModulesHelp { } {
-    global helpmsg
-    puts stderr "\t$helpmsg\n"
+        puts stderr "no so brief information"
+        puts stderr "about this module"
 }
 
-# Only allow one instance of compilers to load
-#
-conflict pgi
-conflict intel
-
-set version 2017
-set inteldir /opt/intel17/compilers_and_libraries
-
-if [ file isdirectory $inteldir ] {
-    module-whatis "Changes the Intel compiler to  $version"
-    set helpmsg "
-Purpose
--------
-This module file defines the system paths and environment variables
-needed to use the Intel Parallel Studio XE $version Composer Edition.
-Includes C++ and/or Fortran compilers, performance libraries, and
-parallel models.
-
-Math library: Intel® Math Kernel Library (Intel® MKL)
-Threading library: Intel® Threading Building Blocks (Intel® TBB)
-Media/data library: Intel® Integrated Performance Primitives (Intel® IPP)
-Numerical analysis functions for Fortran applications: IMSL* numeric library
-Threading and vectorization parallel model: Intel Cilk Plus
-
-Dependencies
-------------
-None.
-
-Documentation
--------------
-  Documentation for Intel Parallel Studio XE $version is available at:
-
-  https://software.intel.com/en-us/intel-software-technical-documentation
-"
-
-    setenv I_MPI_ROOT $inteldir/linux/mpi
-	setenv GDB_CROSS /opt/intel17/debugger_2017/gdb/intel64_mic/bin/gdb-mic
-	setenv INTEL_PYTHONHOME /opt/intel17/debugger_2017/python/intel64/
-	setenv IPPROOT $inteldir/linux/ipp
-	setenv MIC_LD_LIBRARY_PATH $inteldir/linux/mpi/mic/lib:$inteldir/linux/lib/mic:$inteldir/linux/ipp/lib/mic:$inteldir/linux/lib/intel64_lin_mic:$inteldir/linux/mkl/lib/intel64_lin_mic:$inteldir/linux/tbb/lib/mic
-	setenv DAALROOT $inteldir/linux/daal
-	prepend-path PATH /opt/intel17/debugger_2017/gdb/intel64_mic/bin
-	prepend-path PATH $inteldir/linux/mpi/intel64/bin
-	prepend-path PATH $inteldir/linux/bin/intel64
-	append-path PATH /opt/intel17/bin
-	setenv INTEL_LICENSE_FILE /opt/intel17/licenses:$inteldir/linux/licenses:/opt/intel/licenses:/root/intel/licenses
-	setenv CPATH $inteldir/linux/ipp/include:$inteldir/linux/mkl/include:$inteldir/linux/tbb/include:$inteldir/linux/daal/include
-	setenv LD_LIBRARY_PATH $inteldir/linux/lib/intel64:$inteldir/linux/lib/intel64_lin:$inteldir/linux/mpi/intel64/lib:$inteldir/linux/mpi/mic/lib:$inteldir/linux/ipp/lib/intel64:$inteldir/linux/lib/intel64_lin:$inteldir/linux/mkl/lib/intel64_lin:$inteldir/linux/tbb/lib/intel64/gcc4.7:/opt/intel17/debugger_2017/iga/lib:/opt/intel17/debugger_2017/libipt/intel64/lib:$inteldir/linux/daal/lib/intel64_lin:$inteldir/linux/daal/../tbb/lib/intel64_lin/gcc4.4
-	setenv MPM_LAUNCHER /opt/intel17/debugger_2017/mpm/mic/bin/start_mpm.sh
-	setenv MANPATH /opt/intel17/man/common:$inteldir/linux/mpi/man:/opt/intel17/documentation_2017/en/debugger//gdb-ia/man/:/opt/intel17/documentation_2017/en/debugger//gdb-mic/man/:/opt/intel17/documentation_2017/en/debugger//gdb-igfx/man/:/usr/share/man:/opt/stack/man:/usr/local/share/man:
-	setenv LIBRARY_PATH $inteldir/linux/ipp/lib/intel64:$inteldir/linux/lib/intel64_lin:$inteldir/linux/mkl/lib/intel64_lin:$inteldir/linux/tbb/lib/intel64/gcc4.7:$inteldir/linux/daal/lib/intel64_lin:$inteldir/linux/daal/../tbb/lib/intel64_lin/gcc4.4
-	setenv TBBROOT $inteldir/linux/tbb
-	setenv INFOPATH /opt/intel17/documentation_2017/en/debugger//gdb-ia/info/:/opt/intel17/documentation_2017/en/debugger//gdb-mic/info/:/opt/intel17/documentation_2017/en/debugger//gdb-igfx/info/
-	setenv MIC_LIBRARY_PATH $inteldir/linux/mpi/mic/lib:$inteldir/linux/lib/mic:$inteldir/linux/lib/intel64_lin_mic:$inteldir/linux/mkl/lib/intel64_lin_mic:$inteldir/linux/tbb/lib/mic
-	setenv GDBSERVER_MIC /opt/intel17/debugger_2017/gdb/targets/mic/bin/gdbserver
-	setenv MKLROOT $inteldir/linux/mkl
-	setenv NLSPATH $inteldir/linux/lib/intel64/locale/%l_%t/%N:$inteldir/linux/mkl/lib/intel64_lin/locale/%l_%t/%N:/opt/intel17/debugger_2017/gdb/intel64_mic/share/locale/%l_%t/%N:/opt/intel17/debugger_2017/gdb/intel64/share/locale/%l_%t/%N
-	setenv CLASSPATH $inteldir/linux/mpi/intel64/lib/mpi.jar:$inteldir/linux/daal/lib/daal.jar
-} else {
-    module-whatis " Intel Parallel Studio XE $version not installed"
-    set helpmsg "Intel Parallel Studio XE $version not installed"
-    if [ expr [ module-info mode load ] || [ module-info mode display ] ] {
-	     # bring in new version
-	    puts stderr "Intel Parallel Studio XE $version not installed on [uname nodename]"
-    }
-}
-
-# Only allow one instance of compilers to load
+setenv IFORT_COMPILER_LIB /opt/intel17/lib/intel64
+prepend-path CLASSPATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/daal/lib/daal.jar
+prepend-path CLASSPATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/mpi/intel64/lib/mpi.jar
+prepend-path CPATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/daal/include
+prepend-path CPATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/tbb/include
+prepend-path CPATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/mkl/include
+prepend-path CPATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/ipp/include
+setenv DAALROOT /opt/intel17/compilers_and_libraries_2017.4.196/linux/daal
+setenv GDB_CROSS /opt/intel17/debugger_2017/gdb/intel64_mic/bin/gdb-mic
+setenv GDBSERVER_MIC /opt/intel17/debugger_2017/gdb/targets/mic/bin/gdbserver
+setenv I_MPI_ROOT /opt/intel17/compilers_and_libraries_2017.4.196/linux/mpi
+prepend-path INFOPATH /opt/intel17/documentation_2017/en/debugger//gdb-igfx/info/
+prepend-path INFOPATH /opt/intel17/documentation_2017/en/debugger//gdb-mic/info/
+prepend-path INFOPATH /opt/intel17/documentation_2017/en/debugger//gdb-ia/info/
+setenv INTEL_LICENSE_FILE /opt/intel17/compilers_and_libraries_2017.4.196/linux/licenses:/opt/intel/licenses:/home4/gforney/intel/licenses
+setenv INTEL_PYTHONHOME /opt/intel17/debugger_2017/python/intel64/
+setenv IPPROOT /opt/intel17/compilers_and_libraries_2017.4.196/linux/ipp
+prepend-path LD_LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/daal/../tbb/lib/intel64_lin/gcc4.4
+prepend-path LD_LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/daal/lib/intel64_lin
+prepend-path LD_LIBRARY_PATH /opt/intel17/debugger_2017/libipt/intel64/lib
+prepend-path LD_LIBRARY_PATH /opt/intel17/debugger_2017/iga/lib
+prepend-path LD_LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/tbb/lib/intel64/gcc4.7
+prepend-path LD_LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/mkl/lib/intel64_lin
+prepend-path LD_LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/compiler/lib/intel64_lin
+prepend-path LD_LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/ipp/lib/intel64
+prepend-path LD_LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/mpi/mic/lib
+prepend-path LD_LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/mpi/intel64/lib
+prepend-path LD_LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/compiler/lib/intel64_lin
+prepend-path LD_LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/compiler/lib/intel64
+prepend-path LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/daal/../tbb/lib/intel64_lin/gcc4.4
+prepend-path LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/daal/lib/intel64_lin
+prepend-path LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/tbb/lib/intel64/gcc4.7
+prepend-path LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/mkl/lib/intel64_lin
+prepend-path LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/compiler/lib/intel64_lin
+prepend-path LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/ipp/lib/intel64
+prepend-path MANPATH /usr/local/man
+prepend-path MANPATH /usr/share/man
+prepend-path MANPATH /usr/share/man/en
+prepend-path MANPATH /usr/share/man/overrides
+prepend-path MANPATH /usr/local/share/man
+prepend-path MANPATH /usr/local/texlive/2014/bin/x86_64-linux/man
+prepend-path MANPATH /opt/intel17/documentation_2017/en/debugger//gdb-igfx/man/
+prepend-path MANPATH /opt/intel17/documentation_2017/en/debugger//gdb-mic/man/
+prepend-path MANPATH /opt/intel17/documentation_2017/en/debugger//gdb-ia/man/
+prepend-path MANPATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/mpi/man
+prepend-path MANPATH /opt/intel17/man/common
+prepend-path MIC_LD_LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/tbb/lib/mic
+prepend-path MIC_LD_LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/mkl/lib/intel64_lin_mic
+prepend-path MIC_LD_LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/compiler/lib/intel64_lin_mic
+prepend-path MIC_LD_LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/ipp/lib/mic
+prepend-path MIC_LD_LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/compiler/lib/mic
+prepend-path MIC_LD_LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/mpi/mic/lib
+prepend-path MIC_LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/tbb/lib/mic
+prepend-path MIC_LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/mkl/lib/intel64_lin_mic
+prepend-path MIC_LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/compiler/lib/intel64_lin_mic
+prepend-path MIC_LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/compiler/lib/mic
+prepend-path MIC_LIBRARY_PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/mpi/mic/lib
+setenv MKLROOT /opt/intel17/compilers_and_libraries_2017.4.196/linux/mkl
+setenv MPM_LAUNCHER /opt/intel17/debugger_2017/mpm/mic/bin/start_mpm.sh
+prepend-path NLSPATH /opt/intel17/debugger_2017/gdb/intel64/share/locale/%l_%t/%N
+prepend-path NLSPATH /opt/intel17/debugger_2017/gdb/intel64_mic/share/locale/%l_%t/%N
+prepend-path NLSPATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/mkl/lib/intel64_lin/locale/%l_%t/%N
+prepend-path NLSPATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/compiler/lib/intel64/locale/%l_%t/%N
+prepend-path PATH /opt/intel17/debugger_2017/gdb/intel64_mic/bin
+prepend-path PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/mpi/intel64/bin
+prepend-path PATH /opt/intel17/compilers_and_libraries_2017.4.196/linux/bin/intel64
+setenv TBBROOT /opt/intel17/compilers_and_libraries_2017.4.196/linux/tbb


### PR DESCRIPTION
this pull request adds a -M option to qfds.sh to specify an openmpi module if you want to run a case that was built with an openmpi module different than the openmpi module currently loaded. If you don't use the -M option qfds.sh behaves as before ie does not touch any modules. 

example:

qfds.sh -M openmpi/64ib thouse5.fds

Note for now we can only specify one module.  