### PR TITLE
FDS Validation Guide: minor typo

### DIFF
--- a/Manuals/FDS_Validation_Guide/Survey_Chapter.tex
+++ b/Manuals/FDS_Validation_Guide/Survey_Chapter.tex
@@ -183,8 +183,7 @@ Xiao~\cite{Xiao:FT2012} compared FDS simulations with real scale compartment mea
 
 \subsection{Airflows in Fire Compartments}
 
-Friday studied the use of FDS in large scale mechanically ventilated spaces.  The ventilated enclosure was provided with air injection rates of 1 to 12 air changes per hour and a fire with heat release rates ranging from 0.5~MW to 2~MW. The test measurements and model output were compared to assess the accuracy of FDS~\cite{Friday:1}. These simulations have been repeated with the latest version of FDS and reported in this guide under
-the heading ``FM/SNL Test Series.''
+Friday and Mowrer~\cite{Friday:1} studied the use of FDS in large scale mechanically ventilated spaces.  The ventilated enclosure was provided with air injection rates of 1 to 12 air changes per hour and a fire with heat release rates ranging from 0.5~MW to 2~MW. The test measurements and model output were compared to assess the accuracy of FDS. These simulations have been repeated with the latest version of FDS and reported in this guide under the heading ``FM/SNL Test Series.''
 
 Zhang et al.~\cite{Zhang:2} utilized the FDS model to predict turbulence characteristics of the flow and temperature fields due to fire in a compartment.  The experimental data was acquired through tests that replicated a half-scale ISO Room Fire Test. Two cases were explored -- the heat source in the center of the room and the heat source adjacent to a wall. In both cases, the heat source was a heating element with an output of 12~kW/m$^2$.
 


### PR DESCRIPTION
Moving reference from end of sentence to after author name as per rest of Guide.