### PR TITLE
Manuals/Bibliography/commoncommands.tex: Fix DIM GRAY color

### DIFF
--- a/Manuals/Bibliography/commoncommands.tex
+++ b/Manuals/Bibliography/commoncommands.tex
@@ -400,7 +400,7 @@ http://dx.doi.org/10.6028/NIST.SP.#1
 \definecolor{COBALT}{rgb}{0.23922,0.34902,0.67059}
 \definecolor{CORAL}{rgb}{1.00000,0.49804,0.31373}
 \definecolor{CYAN}{rgb}{0.00000,1.00000,1.00000}
-\definecolor{DIMGRAY }{rgb}{0.41176,0.41176,0.41176}
+\definecolor{DIM GRAY }{rgb}{0.41176,0.41176,0.41176}
 \definecolor{EMERALD GREEN}{rgb}{0.00000,0.78824,0.34118}
 \definecolor{FIREBRICK}{rgb}{0.69804,0.13333,0.13333}
 \definecolor{FLESH}{rgb}{1.00000,0.49020,0.25098}


### PR DESCRIPTION
This is a fix to DIM GRAY color. #5684 