### PR TITLE
FDS Source: revert creation of IW for outward domain boundaries in HT3D

### DIFF
--- a/Source/init.f90
+++ b/Source/init.f90
@@ -767,7 +767,7 @@ OBST_LOOP_2: DO N=1,M%N_OBST
       DO J=OB%J1+1,OB%J2
          I = OB%I1+1
          ! Don't assign wall cell index to obstruction face pointing out of the computational domain
-         IF (I==1 .AND. .NOT.OB%HT3D) CYCLE
+         IF (I==1) CYCLE
          IC = M%CELL_INDEX(I-1,J,K)
          IF (M%SOLID(IC) .AND. .NOT.M%OBSTRUCTION(M%OBST_INDEX_C(IC))%REMOVABLE) CYCLE ! Permanently covered face
          IOR = -1
@@ -790,7 +790,7 @@ OBST_LOOP_2: DO N=1,M%N_OBST
       DO J=OB%J1+1,OB%J2
          I = OB%I2
          ! Don't assign wall cell index to obstruction face pointing out of the computational domain
-         IF (I==M%IBAR .AND. .NOT.OB%HT3D) CYCLE
+         IF (I==M%IBAR) CYCLE
          IC = M%CELL_INDEX(I+1,J,K)
          ! Permanently covered face
          IF (M%SOLID(IC) .AND. .NOT.M%OBSTRUCTION(M%OBST_INDEX_C(IC))%REMOVABLE) CYCLE
@@ -814,7 +814,7 @@ OBST_LOOP_2: DO N=1,M%N_OBST
       DO I=OB%I1+1,OB%I2
          J = OB%J1+1
          ! Don't assign wall cell index to obstruction face pointing out of the computational domain
-         IF (J==1 .AND. .NOT.OB%HT3D) CYCLE
+         IF (J==1) CYCLE
          IC = M%CELL_INDEX(I,J-1,K)
          ! Permanently covered face
          IF (M%SOLID(IC) .AND. .NOT.M%OBSTRUCTION(M%OBST_INDEX_C(IC))%REMOVABLE) CYCLE
@@ -838,7 +838,7 @@ OBST_LOOP_2: DO N=1,M%N_OBST
       DO I=OB%I1+1,OB%I2
          J = OB%J2
          ! Don't assign wall cell index to obstruction face pointing out of the computational domain
-         IF (J==M%JBAR .AND. .NOT.OB%HT3D) CYCLE
+         IF (J==M%JBAR) CYCLE
          IC = M%CELL_INDEX(I,J+1,K)
          ! Permanently covered face
          IF (M%SOLID(IC) .AND. .NOT.M%OBSTRUCTION(M%OBST_INDEX_C(IC))%REMOVABLE) CYCLE
@@ -862,7 +862,7 @@ OBST_LOOP_2: DO N=1,M%N_OBST
       DO I=OB%I1+1,OB%I2
          K = OB%K1+1
          ! Don't assign wall cell index to obstruction face pointing out of the computational domain
-         IF (K==1 .AND. .NOT.OB%HT3D) CYCLE
+         IF (K==1) CYCLE
          IC = M%CELL_INDEX(I,J,K-1)
          ! Permanently covered face
          IF (M%SOLID(IC) .AND. .NOT.M%OBSTRUCTION(M%OBST_INDEX_C(IC))%REMOVABLE) CYCLE
@@ -886,7 +886,7 @@ OBST_LOOP_2: DO N=1,M%N_OBST
       DO I=OB%I1+1,OB%I2
          K = OB%K2
          ! Don't assign wall cell index to obstruction face pointing out of the computational domain
-         IF (K==M%KBAR .AND. .NOT.OB%HT3D) CYCLE
+         IF (K==M%KBAR) CYCLE
          IC = M%CELL_INDEX(I,J,K+1)
          ! Permanently covered face
          IF (M%SOLID(IC) .AND. .NOT.M%OBSTRUCTION(M%OBST_INDEX_C(IC))%REMOVABLE) CYCLE
@@ -1782,7 +1782,8 @@ DO K=1,M%KBAR
       DO I=1,M%IBAR
          OTHER_MESH_LOOP: DO NOM=1,NM-1
             M2=>MESHES(NOM)
-            IF (M%X(I-1)>=M2%XS .AND. M%X(I)<=M2%XF .AND.  M%Y(J-1)>=M2%YS .AND. M%Y(J)<=M2%YF .AND. &
+            IF (M%X(I-1)>=M2%XS .AND. M%X(I)<=M2%XF .AND. &
+                M%Y(J-1)>=M2%YS .AND. M%Y(J)<=M2%YF .AND. &
                 M%Z(K-1)>=M2%ZS .AND. M%Z(K)<=M2%ZF) THEN
                M%INTERPOLATED_MESH(I,J,K) = NOM
                EXIT OTHER_MESH_LOOP

--- a/Source/wall.f90
+++ b/Source/wall.f90
@@ -899,13 +899,13 @@ SUBSTEP_LOOP: DO WHILE ( ABS(T_LOC-DT_BC_HT3D)>TWO_EPSILON_EB )
 
       END SELECT METHOD_OF_HEAT_TRANSFER
 
-      ! handle special case of 2D cylindrical coordinates with WC on X=0 boundary
-
-      IF (TWO_D .AND. CYLINDRICAL .AND. IOR==-1 .AND. ABS(XS)<TWO_EPSILON_EB) THEN
-         KDTDX(II-1,JJ,KK) = 0._EB
-      ENDIF
-
    ENDDO HT3D_WALL_LOOP
+
+   ! handle special case of 2D cylindrical coordinates with WC on X=0 boundary
+
+   IF (TWO_D .AND. CYLINDRICAL .AND. ABS(XS)<TWO_EPSILON_EB) THEN
+      KDTDX(0,1,:) = 0._EB
+   ENDIF
 
    DO K=1,KBAR
       DO J=1,JBAR


### PR DESCRIPTION
In this PR we are reverting creating WALL CELLS for HT3D OBST at domain boundaries.  This led to too many array access violations for IIG, etc.  For now, explicit SURF boundary conditions for HT3D must be set at *interior* cells.

Note that the MIRROR boundary at X=0 for CYLINDRICAL is a special case that still functions.