### PR TITLE
FDS Source: set SF%EMISSIVITY to ML%EMISSIVITY for HT3D

### DIFF
--- a/Source/read.f90
+++ b/Source/read.f90
@@ -6855,24 +6855,24 @@ PROCESS_SURF_LOOP: DO N=0,N_SURF
 
    SF%INTERNAL_RADIATION = .FALSE.
    DO NL=1,SF%N_LAYERS
-   DO NN =1,SF%N_LAYER_MATL(NL)
-      ML => MATERIAL(SF%LAYER_MATL_INDEX(NL,NN))
-      IF (ML%KAPPA_S<5.0E4_EB) SF%INTERNAL_RADIATION = .TRUE.
-   ENDDO
+      DO NN =1,SF%N_LAYER_MATL(NL)
+         ML => MATERIAL(SF%LAYER_MATL_INDEX(NL,NN))
+         IF (ML%KAPPA_S<5.0E4_EB) SF%INTERNAL_RADIATION = .TRUE.
+      ENDDO
    ENDDO
 
    ! In case of internal radiation, do not allow zero-emissivity
 
    IF (SF%INTERNAL_RADIATION) THEN
       DO NL=1,SF%N_LAYERS
-      DO NN =1,SF%N_LAYER_MATL(NL)
-         ML => MATERIAL(SF%LAYER_MATL_INDEX(NL,NN))
-         IF (ML%EMISSIVITY == 0._EB) THEN
-            WRITE(MESSAGE,'(A)') 'ERROR: Zero emissivity of MATL '//TRIM(MATL_NAME(SF%LAYER_MATL_INDEX(NL,NN)))// &
-            ' is inconsistent with internal radiation in SURF '//TRIM(SF%ID)//'.'
-            CALL SHUTDOWN(MESSAGE) ; RETURN
-         ENDIF
-      ENDDO
+         DO NN =1,SF%N_LAYER_MATL(NL)
+            ML => MATERIAL(SF%LAYER_MATL_INDEX(NL,NN))
+            IF (ML%EMISSIVITY == 0._EB) THEN
+               WRITE(MESSAGE,'(A)') 'ERROR: Zero emissivity of MATL '//TRIM(MATL_NAME(SF%LAYER_MATL_INDEX(NL,NN)))// &
+               ' is inconsistent with internal radiation in SURF '//TRIM(SF%ID)//'.'
+               CALL SHUTDOWN(MESSAGE) ; RETURN
+            ENDIF
+         ENDDO
       ENDDO
    ENDIF
 
@@ -8385,6 +8385,10 @@ MESH_LOOP: DO NM=1,NMESHES
                      CALL SHUTDOWN(MESSAGE) ; RETURN
                   ENDIF
                   OB%INTERNAL_HEAT_SOURCE = INTERNAL_HEAT_SOURCE * 1000._EB ! W/m^3
+
+                  DO NNN=0,N_SURF
+                     IF ( ANY(OB%SURF_INDEX==NNN) ) SURFACE(NNN)%EMISSIVITY=MATERIAL(NNN)%EMISSIVITY
+                  ENDDO
                ENDIF
 
                ! Make obstruction invisible if it's within a finer mesh

--- a/Source/wall.f90
+++ b/Source/wall.f90
@@ -579,7 +579,7 @@ SUBROUTINE SOLID_HEAT_TRANSFER_3D
 ! Solves the 3D heat conduction equation internal to OBSTs.
 
 REAL(EB) :: DT_SUB,T_LOC,RHO_S,K_S,C_S,TMP_G,TMP_F,TMP_S,RDN,HTC,K_S_M,K_S_P,TMP_OTHER,RAMP_FACTOR,&
-            QNET,TSI,FDERIV,QEXTRA,K_S_MAX,VN_HT3D,DN,KDTDN,R_K_S,TMP_I
+            QNET,TSI,FDERIV,QEXTRA,K_S_MAX,VN_HT3D,DN,KDTDN,R_K_S,TMP_I,TH_EST4,FO_EST3
 INTEGER  :: II,JJ,KK,I,J,K,IOR,IC,ICM,ICP,IIG,JJG,KKG,NR,ADCOUNT,SUBIT,NWP
 REAL(EB), POINTER, DIMENSION(:,:,:) :: KDTDX=>NULL(),KDTDY=>NULL(),KDTDZ=>NULL(),TMP_NEW=>NULL()
 TYPE(OBSTRUCTION_TYPE), POINTER :: OB=>NULL(),OBM=>NULL(),OBP=>NULL()
@@ -879,8 +879,10 @@ SUBSTEP_LOOP: DO WHILE ( ABS(T_LOC-DT_BC_HT3D)>TWO_EPSILON_EB )
                CASE( 3); RDN = RDZ(KK)
             END SELECT
             IF (RADIATION) THEN
-               TMP_F = ( WC%ONE_D%QRADIN +                    HTC*TMP_G + 2._EB*K_S*RDN*TMP_S ) / &
-                       ( WC%ONE_D%EMISSIVITY*SIGMA*TMP_F**3 + HTC       + 2._EB*K_S*RDN       )
+               TH_EST4 = 3._EB*WC%ONE_D%EMISSIVITY*SIGMA*TMP_F**4
+               FO_EST3 = 4._EB*WC%ONE_D%EMISSIVITY*SIGMA*TMP_F**3
+               TMP_F = ( WC%ONE_D%QRADIN + TH_EST4 + HTC*TMP_G + 2._EB*K_S*RDN*TMP_S ) / &
+                       (                   FO_EST3 + HTC       + 2._EB*K_S*RDN       )
             ELSE
                TMP_F = ( HTC*TMP_G + 2._EB*K_S*RDN*TMP_S ) / &
                        ( HTC       + 2._EB*K_S*RDN       )


### PR DESCRIPTION
This PR addresses Issue #5791.  Main issue was that EMISSIVITY from MATL was not being transferred to SURFACE%EMISSIVITY for HT3D.  But I also reworked the linearization of the QRADOUT term at the surface to match the way Simo does it in 1D pyrolysis.