### PR TITLE
qfds: temporary fix to -t option - use NCORES_COMPUTENODE variable to…

### DIFF
--- a/Utilities/Scripts/qfds.sh
+++ b/Utilities/Scripts/qfds.sh
@@ -225,6 +225,9 @@ case $OPTION  in
    ;;
   t)
    benchmark="yes"
+   if [ "$NCORES_COMPUTENODE" != "" ]; then
+     nmpi_processes_per_node="$NCORES_COMPUTENODE"
+   fi
    ;;
   T)
    TYPE="$OPTARG"


### PR DESCRIPTION
… set number of cores allocated when using benchmark option (naccesspolicy option not working)

this is a temporary fix until we figure out why the naccesspolicy option is not working assign exclusive use of a node to a job.