### PR TITLE
FDS Source: Evacuation fix for read_obst (read.f90) and evac.f90 bug …

### DIFF
--- a/Source/evac.f90
+++ b/Source/evac.f90
@@ -15823,7 +15823,7 @@ CONTAINS
     END IF
 
     ! Only those doors are possible which are in the same main evac mesh.
-    K_ave_Door        = 0.0_EB
+    K_ave_door        = 0.0000001_EB*ABS(FED_DOOR_CRIT)
     FED_max_Door      = 0.0_EB
     Is_Known_Door     = .FALSE.
     Is_Visible_Door   = .FALSE.
@@ -16152,10 +16152,7 @@ CONTAINS
           PP_see_door = PP_see_door .OR. (PP_see_doorXB .AND. PP_correct_side)
              
           FED_max_Door(i) = max_fed
-          K_ave_Door(i) = ave_K
-          IF (FED_DOOR_CRIT < TWO_EPSILON_EB) THEN
-             K_ave_door(i) = MAX(K_ave_Door(i),0.5_EB*ABS(FED_DOOR_CRIT)) ! no divisions by zero
-          END IF
+          K_ave_Door(i) = MAX(ave_K,0.5_EB*ABS(FED_DOOR_CRIT)) ! no divisions by zero
 
           ! Note: a DOOR is not counted as visible door, if it does not have an
           ! EXIT_SIGN, unless it is already been a target door for this agent/group.

--- a/Source/read.f90
+++ b/Source/read.f90
@@ -8924,8 +8924,9 @@ CONTAINS
              CASE (+2)
                 IF (MESHES(NM)%YF <= EMESH_EXITS(N)%XB(4)+TINY) CYCLE NEND_LOOP_1
              END SELECT
-             N_OBST = N_OBST + 1
-             EMESH_EXITS(N)%I_OBST = N_OBST
+             N_OBST_DIM = N_OBST_DIM + 1
+             N_OBST_O   = N_OBST_O   + 1
+             EMESH_EXITS(N)%I_OBST = N_OBST_O
              EVACUATION_OBST = .TRUE.
           END IF
        END DO NEND_LOOP_1
@@ -8951,8 +8952,9 @@ CONTAINS
              EMESH_STAIRS(N)%XB_CORE(3) = MESHES(NM)%Y(J1)
              EMESH_STAIRS(N)%XB_CORE(4) = MESHES(NM)%Y(J2)
 
-             N_OBST = N_OBST + 1
-             EMESH_STAIRS(N)%I_OBST = N_OBST
+             N_OBST_DIM = N_OBST_DIM + 1
+             N_OBST_O   = N_OBST_O   + 1
+             EMESH_STAIRS(N)%I_OBST = N_OBST_O
              EVACUATION_OBST = .TRUE.
           END IF
        END DO NSTRS_LOOP_1


### PR DESCRIPTION
…fix.

N_OBST_DIM is now handled by DEFINE_EVACUATION_OBSTS in READ_OBST.

A tiny bug fix for evac.f90, now K_ave_door is such that there is no
division by zero anymore.