### PR TITLE
Doc: Add 'PARTICLE WEIGHTING FACTOR' to particle output options.

### DIFF
--- a/Manuals/FDS_User_Guide/FDS_User_Guide.tex
+++ b/Manuals/FDS_User_Guide/FDS_User_Guide.tex
@@ -7277,7 +7277,10 @@ The parameter {\ct QUANTITIES} on the {\ct PART} line is an array of character s
 {\ct 'PARTICLE VELOCITY'} (m/s) \\
 {\ct 'PARTICLE MASS'} (kg) \\
 {\ct 'PARTICLE AGE'} (s) \\
+{\ct 'PARTICLE WEIGHTING FACTOR'} \\
 By default, if no {\ct QUANTITIES} are specified and none are selected in Smokeview, then Smokeview will display particles with a single color. To select this color specify either {\ct RGB} or {\ct COLOR}. By default, water droplets are colored blue. All others are colored black.
+
+The {\ct PARTICLE WEIGHTING FACTOR} describes how many actual particles each of the computational particles represent.
 
 For solid particles with a specified {\ct SURF\_ID}, you may specify any of the solid phase output quantities listed in Table~\ref{tab:output}. If the specified quantity is associated with a species, use the parameter \linebreak[4] {\ct QUANTITIES\_SPEC\_ID(N)} to specify the species. Here {\ct N} refers to the order of the specified output quantities on the {\ct PART} line.
 


### PR DESCRIPTION
We stumbled over the PARTICLE WEIGHTING FACTOR in our studies, and thought it should be mentioned in the User Guide.
Feel free to change anything you like.

Best, Marc