### PR TITLE
terrain: add windows batch file for generating gatlinburg test cases

### DIFF
--- a/Utilities/Misc/terrain_vegetation/Make_Gatlinburg_fds_input.bat
+++ b/Utilities/Misc/terrain_vegetation/Make_Gatlinburg_fds_input.bat
@@ -1,0 +1,15 @@
+@echo off
+
+:: Produce fds input files with terrains in both formats, ZVALS (&GEOM) and &OBSTs.
+:: This routine is a specialized version of smv/Build/dem2fds/data/test3.sh, for Gatlinburg test case.
+:: Should run from both Blaze and Burn.
+
+:: Relative location of compiled dem2fds. Assumes both fds and smv repos are in the same directory.
+set dem2fds=..\..\..\..\smv\Build\dem2fds\intel_win_64\dem2fds_win_64
+
+:: terrain directory containing DEM (Digital Elevation Model) and image data. 
+set terraindir=%userprofile%\terrain
+
+
+%dem2fds% -fds   Gatlinburg_1000m.fds       -dir %terraindir%\gatlinburg Gatlinburg_1000m.in
+%dem2fds% -fds Gatlinburg_1000m_g.fds -geom -dir %terraindir%\gatlinburg Gatlinburg_1000m.in


### PR DESCRIPTION
the batch file assumes the terrain files are in the user's home directory

%userprofile%\terrain