### PR TITLE
FDS Source: fix problem with OBST AREA_ADJUST for SHAPE

### DIFF
--- a/Source/read.f90
+++ b/Source/read.f90
@@ -8729,6 +8729,13 @@ MESH_LOOP: DO NM=1,NMESHES
                      N_OBST = N_OBST-1
                      CYCLE I_MULT_LOOP
                   ENDIF
+                  ! For now, we have to adjust the specified OBST box positions so that INPUT_AREA will be reasonable for SHAPE.
+                  OB%X1=X(OB%I1)
+                  OB%X2=X(OB%I2)
+                  OB%Y1=Y(OB%J1)
+                  OB%Y2=Y(OB%J2)
+                  OB%Z1=Z(OB%K1)
+                  OB%Z2=Z(OB%K2)
                ENDIF
 
                ! Check to see if obstruction is completely embedded in another


### PR DESCRIPTION
The specified mass flux at a boundary is not adjusted for SHAPE.  This is a temporary fix for the problem of creating accurate AREA_ADJUST for the MULT OBST SHAPE method.  For now, the resulting Cartesian face area resulting from the MULT SHAPE intersection is what is used for the surface area.  Therefore, reasonable grid resolution is needed to accurate mass flow rates. 