### PR TITLE
FDS guides: clarify secondary breakup and wake drag reduction documentation

### DIFF
--- a/Manuals/Bibliography/FDS_general.bib
+++ b/Manuals/Bibliography/FDS_general.bib
@@ -1255,12 +1255,12 @@
 }
 
 @ARTICLE{Drean2018,
-  author	   = {V. Drean and R. Schillinger and H. Leborgne and G. Auguin and E. Guillaume},
-  title 	   = {{Numerical Simulation of Fire Exposed Fa{\c{c}}ades Using LEPIR II Testing Facility}},
-  journal	   = {Fire Technology},
+  author    = {V. Drean and R. Schillinger and H. Leborgne and G. Auguin and E. Guillaume},
+  title     = {{Numerical Simulation of Fire Exposed Fa{\c{c}}ades Using LEPIR II Testing Facility}},
+  journal      = {Fire Technology},
   month        = {March},
-  year		   = {2018},
-  note	       = {\href{https:doi.org/10.1007/s10694-018-0718-y}{https:doi.org/10.1007/s10694-018-0718-y}}
+  year         = {2018},
+  note          = {\href{https:doi.org/10.1007/s10694-018-0718-y}{https:doi.org/10.1007/s10694-018-0718-y}}
 }
 
 @INPROCEEDINGS{Dreisbach:Interflam,
@@ -2129,12 +2129,12 @@
 }
 
 @ARTICLE{Hartman_2012,
-	author       = {J.R. Hartman and A.P. Beyler and S. Riahi and C.L.Belyer},
-	title        = {{Smoke oxidation kinetics for application to prediction of clean burn patterns}},
-	journal      = {Fire and Materials},
-	volume       = {36},
-	pages        = {177-184},
-	year         = {2012}
+   author       = {J.R. Hartman and A.P. Beyler and S. Riahi and C.L.Belyer},
+   title        = {{Smoke oxidation kinetics for application to prediction of clean burn patterns}},
+   journal      = {Fire and Materials},
+   volume       = {36},
+   pages        = {177-184},
+   year         = {2012}
 }
 
 @ARTICLE{Harlow:1,
@@ -3076,14 +3076,14 @@ volume         = {20}
 }
 
 @ARTICLE{May:2017,
-	Author = {May, Sandra and Berger, Marsha},
-	Journal = {Journal of Scientific Computing},
-	Month = {Jun},
-	Number = {3},
-	Pages = {919--943},
-	Title = {An Explicit Implicit Scheme for Cut Cells in Embedded Boundary Meshes},
-	Volume = {71},
-	Year = {2017}
+   Author = {May, Sandra and Berger, Marsha},
+   Journal = {Journal of Scientific Computing},
+   Month = {Jun},
+   Number = {3},
+   Pages = {919--943},
+   Title = {An Explicit Implicit Scheme for Cut Cells in Embedded Boundary Meshes},
+   Volume = {71},
+   Year = {2017}
 }
 
 @INPROCEEDINGS{Morehart:1991,
@@ -5929,10 +5929,10 @@ volume         = {20}
 }
 
 @MANUAL{IEEE:730,
-	Edition = {{IEEE Std 730-2002}},
-	Organization = {The Institute of Electrical and Electronics Engineers},
-	Title = {IEEE Standard for Software Quality Assurance Plans},
-	Year = {2002}
+   Edition = {{IEEE Std 730-2002}},
+   Organization = {The Institute of Electrical and Electronics Engineers},
+   Title = {IEEE Standard for Software Quality Assurance Plans},
+   Year = {2002}
 }
 
 @TECHREPORT{NIST_NCSTAR_1,
@@ -6505,4 +6505,14 @@ volume         = {20}
   journal      = {Report of Fire Research Institute of Japan},
   volume       = {57},
   year         = {1984}
+}
+
+@article{Bhattacharyya2008,
+   title = {The mean distance to the $n$th neighbour in a uniform distribution of random points: an application of probability theory},
+   volume = {29},
+   number = {3},
+   journal = {European Journal of Physics},
+   author = {Bhattacharyya, Pratip and Chakrabarti, Bikas K.},
+   year = {2008},
+   pages = {639--645}
 }

--- a/Manuals/FDS_Technical_Reference_Guide/Particle_Chapter.tex
+++ b/Manuals/FDS_Technical_Reference_Guide/Particle_Chapter.tex
@@ -76,29 +76,34 @@ Typically, Lagrangian particle models only consider two-way coupling between the
 
 In a configuration where two particles with the same diameter are directly in line, the reduction of the drag force on the second particle can be modeled by the following~\cite{Ramirez:1}:
 \be
-  C_{\rm d} = C_{\rm d,0} \, \frac{F}{F_0} \label{eq:dragred}
+  C_{\rm d} = C_{\rm d,0} \, \frac{F}{F_0}, \label{eq:dragred}
 \ee
 where $C_{\rm d,0}$ is the single particle drag coefficient and $F / F_0$ is the hydrodynamic force ratio of the trailing particle to an isolated particle:
 \be
   \frac{F}{F_0} = W \left[ 1 + \frac{\RE}{16} \frac{1}{\left( L / D - 1
   / 2 \right)^2} \exp \left( - \frac{\RE}{16} \frac{1}{\left( L / D - 1
-  / 2 \right)^{}} \right) \right] \label{eq:dragredfact}
+  / 2 \right)^{}} \right) \right]. \label{eq:dragredfact}
 \ee
-where Re is the single particle Reynolds number, L is the distance between the particles, and W is the non-dimensional, non-disturbed wake velocity at the center of the trailing particle
+where $\RE$ is the single particle Reynolds number, $L$ is the distance between the particles, and $W$ is the non-dimensional, non-disturbed wake velocity at the center of the trailing particle
 \be
   W = 1 - \frac{C_{\rm d,0}}{2} \left[ 1 - \exp \left( - \frac{\RE}{16}
-  \frac{1}{\left( L / D - 1 / 2 \right)} \right) \right] \label{eq:Wake-Vel}
+  \frac{1}{\left( L / D - 1 / 2 \right)} \right) \right]. \label{eq:Wake-Vel}
 \ee
-This model assumes that the spheres are traveling directly in-line with each other. As such, this provides an upper bound for the strength of the aerodynamic interactions between two particles of the same size. The separation distance $L/D$ between particle centers is calculated from the local particle volume fraction and local average particle diameter $\bar{D}$
+This model assumes that the spheres are traveling directly in-line with each other. As such, this provides an upper bound for the strength of the aerodynamic interactions between two particles of the same size. The average separation distance $L/D$ between particle centers is calculated from the local particle volume fraction and local average particle diameter $\bar{D}$ via
 \be
-  L/D = \bar{D} \left(\pi/6\alpha \right)^{\frac{1}{3}}
+  L/D = \bar{D} \left(\pi/6\alpha \right)^{\frac{1}{3}}.
 \ee
-Here, local quantities are averaged over a single computational cell.
+This simple approximation assumes that particles are uniformly distributed in each computational cell~\cite{Bhattacharyya2008}.
 
 In reality, the spray is not monodisperse and the separation distance between the interacting particles varies. In the simulation, the drag reduction factor in Eq.~\ref{eq:dragred} is only used when the local droplet volume fraction exceeds \num{1e-5}. The drag reduction model is turned on by default.
 
-An alternative approach to drag reduction was provided by Prahl et al.~\cite{Prahl:1} who studied the interaction between two solid spheres in steady or pulsating flow by detailed numerical simulations. According to their study, the above correlation under-estimates the drag reduction significantly at small drop-to-drop distances. The inflow pulsations were found to reduce the effect of the drag reduction. At large distances, the two results are similar, the Ram\'{\i}rez-Mu\~{n}oz correlation showing more drag reduction. This is not surprising since the velocity profile of a fully developed axi-symmetric wake behind an axi-symmetric body is used in developing the drag reduction correction in Eqs.~\ref{eq:dragredfact} and \ref{eq:Wake-Vel}. At short distances, the wake is not fully developed and the assumption does not hold.
+As $L/D$ approaches zero, the drag coefficient approaches
+\be
+  C_{\rm d} = C_{\rm d,0} \left(1 - \frac{C_{\rm d,0}}{2}\right),
+\ee
+which is 78\% of that for an isolated spherical particle.
 
+An alternative approach to drag reduction was provided by Prahl et al.~\cite{Prahl:1} who studied the interaction between two solid spheres in steady or pulsating flow by detailed numerical simulations. According to their study, the above equation underestimates the drag reduction significantly at small drop-to-drop distances. The inflow pulsations were found to reduce the effect of the drag reduction. At large distances, the two results are similar, the Ram\'{\i}rez-Mu\~{n}oz correlation showing more drag reduction. This is not surprising since the velocity profile of a fully developed axi-symmetric wake behind an axi-symmetric body is used in developing the drag reduction correction in Eqs.~\ref{eq:dragredfact} and \ref{eq:Wake-Vel}. At short distances, the wake is not fully developed and the assumption does not hold.
 
 \newpage
 \section{Liquid Droplet Size Distribution}

--- a/Manuals/FDS_User_Guide/FDS_User_Guide.tex
+++ b/Manuals/FDS_User_Guide/FDS_User_Guide.tex
@@ -6209,8 +6209,7 @@ If you set {\ct CHECK\_DISTRIBUTION=.TRUE.} on the {\ct PART} line, FDS will wri
 \label{info:secondary_breakup}
 
 If {\ct BREAKUP=.TRUE.} is set on the {\ct PART} line, particles may undergo secondary breakup.
-In this case you should also specify the {\ct SURFACE\_TENSION} (N/m) of the liquid and the resulting ratio of the Sauter mean diameters,
-{\ct BREAKUP\_RATIO}. Its default is 3/7. Optionally, specify the distribution parameters \linebreak[4]{\ct BREAKUP\_GAMMA\_D} and {\ct BREAKUP\_SIGMA\_D}.
+In this case you should also specify the {\ct SURFACE\_TENSION} (N/m) of the liquid and the resulting ratio of the median volumetric diameter, $D_{\rm v,0.5}$, {\ct BREAKUP\_RATIO}. Its default is 3/7. Optionally, specify the distribution parameters \linebreak[4]{\ct BREAKUP\_GAMMA\_D} and {\ct BREAKUP\_SIGMA\_D}. These parameters are defined the same as {\ct GAMMA\_D} and {\ct SIGMA\_D} in section~\ref{info:particle_size} but instead apply after breakup.
 
 \subsection{Dense Clouds of Droplets}
 \label{info:DENSE_VOLUME_FRACTION}


### PR DESCRIPTION
My text editor is configured to change tabs to spaces, so some tabs in the BibTeX file were unintentionally changed as well. These changes are harmless and might be preferred for consistency.