### PR TITLE
An Error in FDS_EVAC User Guide

### DIFF
--- a/Manuals/FDS_Evacuation_Guide/FDS+EVAC_Guide.tex
+++ b/Manuals/FDS_Evacuation_Guide/FDS+EVAC_Guide.tex
@@ -1897,9 +1897,7 @@ are heading towards an exit, they start to follow these other agents.
 A herding agent will remain still even after detecting the fire and
 its reaction time has passed if it has not been able to select any
 exit either by being familiar with it or by observing other agents.
-If the nearest neighbors of a herding agent are heading towards some
-exit then the herding agent starts to follow these agents almost
-immediately regardless of its detection and reaction times.  If there
+If there
 are available familiar exits at a given floor for a herding agent then
 it behaves like a conservative agent, i.e., the familiar route
 behavior overrides the herding behavior.


### PR DESCRIPTION
I tested an example and it shew that herding agents cannot follow others before their detection and reaction times are reached.  So I suggest that the sentence in FDS_EVAC User Guide should be deleted or modified because it is not consistent with the testing result.  

The discussion is listed in the google forum as below.  
https://groups.google.com/forum/?fromgroups#!topic/fds-smv/qNAbpZ8Y2-A

Best Regards