### PR TITLE
Doc: Updated particle output options.

### DIFF
--- a/Manuals/FDS_User_Guide/FDS_User_Guide.tex
+++ b/Manuals/FDS_User_Guide/FDS_User_Guide.tex
@@ -7879,6 +7879,9 @@ The parameter {\ct QUANTITIES} on the {\ct PART} line is an array of character s
 {\ct 'PARTICLE MASS'} (kg) \\
 {\ct 'PARTICLE AGE'} (s) \\
 {\ct 'PARTICLE WEIGHTING FACTOR'} \\
+{\ct 'PARTICLE PHASE'} \\
+{\ct 'PARTICLE X'}, {\ct 'PARTICLE Y'}, {\ct 'PARTICLE Z'} (m) \\
+{\ct 'PARTICLE U'}, {\ct 'PARTICLE V'}, {\ct 'PARTICLE W'} (m/s) \\
 By default, if no {\ct QUANTITIES} are specified and none are selected in Smokeview, then Smokeview will display particles with a single color. To select this color specify either {\ct RGB} or {\ct COLOR}. By default, water droplets are colored blue. All others are colored black.
 
 The {\ct PARTICLE WEIGHTING FACTOR} describes how many actual particles each of the computational particles represent.


### PR DESCRIPTION
According to the following lines of code, there are some more output options for particle quantities available than the FDS User Guide describes. This pull requests completes the documentation by the remaining options.

https://github.com/firemodels/fds/blob/78a399d9b56d802b6de4e0d9c931e89d03e2f814/Source/dump.f90#L7814

Follow-up to #6022.