### PR TITLE
FDS Source: Evacuation fix for mpi and for the prt5.bnd files

### DIFF
--- a/Source/dump.f90
+++ b/Source/dump.f90
@@ -534,10 +534,13 @@ MESH_LOOP: DO NM=1,NMESHES
    IF (EVACUATION_ONLY(NM)) THEN
       IF (EMESH_INDEX(NM)>0) THEN
          LU_PART(NM) = GET_FILE_NUMBER()
+         LU_PART(NM+NMESHES) = GET_FILE_NUMBER()
          IF (NMESHES>1) THEN
             WRITE(FN_PART(NM),'(A,I4.4,A)') TRIM(CHID)//'_',NM,'.prt5'
+            WRITE(FN_PART(NM+NMESHES),'(A,I4.4,A)') TRIM(CHID)//'_',NM,'.prt5.bnd'
          ELSE
             WRITE(FN_PART(NM),'(A,A)') TRIM(CHID),'.prt5'
+            WRITE(FN_PART(NM+NMESHES),'(A,A)') TRIM(CHID),'.prt5.bnd'
          ENDIF
       END IF
    ENDIF

--- a/Source/evac.f90
+++ b/Source/evac.f90
@@ -14807,7 +14807,7 @@ CONTAINS
     ! Local variables
     INTEGER :: NPP,NPLIM,i,izero,nn,n
     LOGICAL :: CROWBAR_DUMP
-    REAL(EB) :: TNOW, EVEL, angle_hr
+    REAL(EB) :: TNOW, EVEL, angle_hr, PART_MIN, PART_MAX
     REAL(FB), ALLOCATABLE, DIMENSION(:) :: XP,YP,ZP
     REAL(FB), ALLOCATABLE, DIMENSION(:,:) :: QP, AP
     INTEGER, ALLOCATABLE, DIMENSION(:) :: TA
@@ -14977,7 +14977,22 @@ CONTAINS
           WRITE(LU_PART(NM)) ((QP(I,NN),I=1,NPLIM),NN=1,EVAC_N_QUANTITIES)
        END IF
        !
+       WRITE(LU_PART(NM+NMESHES),'(ES13.6,1X,I4)')T, EVAC_N_QUANTITIES
        IF (EVAC_N_QUANTITIES > 0) THEN
+          DO NN = 1, EVAC_N_QUANTITIES
+             IF (NPLIM > 0) THEN
+                PART_MAX = QP(1,NN)
+                PART_MIN = PART_MAX
+                DO I = 2, NPLIM
+                   PART_MIN = MIN(QP(I,NN),PART_MIN)
+                   PART_MAX = MAX(QP(I,NN),PART_MAX)
+                END DO
+             ELSE
+                PART_MIN = 1.0_EB
+                PART_MAX = 0.0_EB
+             ENDIF
+             WRITE(LU_PART(NM+NMESHES),'(5X,ES13.6,1X,ES13.6)')PART_MIN, PART_MAX
+          ENDDO
           DEALLOCATE(QP)
        END IF
        DEALLOCATE(AP)

--- a/Source/read.f90
+++ b/Source/read.f90
@@ -877,6 +877,12 @@ MESH_LOOP: DO N=1,NMESHES_READ
 ENDDO MESH_LOOP
 
 NM_EVAC = NM
+IF (ANY(EVACUATION_ONLY)) THEN
+   DO NM=1,NMESHES
+      IF(EVACUATION_ONLY(NM)) PROCESS(NM)=MAX(0,EVAC_PROCESS)
+   ENDDO
+ENDIF
+
 
 ! Check if there are too many MPI processes assigned to the job
 


### PR DESCRIPTION
Now also the evacuation meshes has output for the prt5.bnd files.
Now fds is running without error messages, but I do not know if
Smokeview can read the evacuation mesh prt5.bnd files, but this
is an another issue.

Also now the mpi with multiple presesses is fine for fire+evacuation
simulation. The PROCESS(NM) is set =MAX(0,EVAC_PROCESS) for the
evacuation meshes, before it was undefined for evacuation meshes
(or was it zero?).

Both changes do not modify "the fire source code", i.e., they are
done just for the evacuation meshes and/or have "evacuation if"
around the modifications.