### PR TITLE
Shortening race_test_4.fds

### DIFF
--- a/Verification/Thread_Check/race_test_4.fds
+++ b/Verification/Thread_Check/race_test_4.fds
@@ -7,7 +7,7 @@
 &MESH IJK= 6, 6,32, XB=-0.15, 0.15,-0.45,-0.15, 0.00, 1.60 /
 &MESH IJK= 6, 6,32, XB=-0.15, 0.15, 0.15, 0.45, 0.00, 1.60 /
 
-&TIME T_END=10. /
+&TIME T_END=1.2 /
 
 &REAC FUEL='N-HEXANE'
       CO_YIELD=0.100


### PR DESCRIPTION
Reducing the time of the Inspection case will reduce accuracy to some unknown extent, but 1.2 s tends to be adequate in my personal testing. This is a necessary edit so Firebot can finish its nightly run in a timely manner.