### PR TITLE
FDS Source: Simplify evacuation part in read_zone (read.f90)

### DIFF
--- a/Manuals/FDS_Evacuation_Guide/FDS+EVAC_Guide.tex
+++ b/Manuals/FDS_Evacuation_Guide/FDS+EVAC_Guide.tex
@@ -625,7 +625,7 @@ boundary of a agent crowd).  If ``straight towards door'' would mean
 turning towards a high left (or right) density then the flow field is
 used instead.
 
-If \Timtt{EVAC\_FDS6=.TRUE.} is given then the user should not give
+When writing an input file for FDS6, the user should not give
 any additional evacuation flow fields nor vents.  There are two basic
 levels in the evacuation meshes.  One is the main evacuation mesh
 location at the $z$-level given by the \Timtt{XB} on the mesh line.

--- a/Manuals/FDS_Evacuation_Guide/FDS+EVAC_Guide.tex
+++ b/Manuals/FDS_Evacuation_Guide/FDS+EVAC_Guide.tex
@@ -521,7 +521,7 @@ much from the version 2.5.0.  Just some bugs are corrected.
 \noindent The version 2.5.0 of the evacuation module does not differ
 much from the version 2.4.1.  Just some bugs are corrected and some
 old user input are disabled.  This version does not support anymore
-FDS 5 style evacuation inputs.  Now just the main evacuation meshes
+FDS 5 style evacuation inputs, and \Timtt{EVAC\_FDS6=.FALSE.} is not supported anymore.  Now just the main evacuation meshes
 are defined by the user and no ``outflow'' vents are defined.  The
 \Timtt{STRS} namelist for the staircases is more automatic, it defines
 its own mesh(es) automatically.

--- a/Source/read.f90
+++ b/Source/read.f90
@@ -11749,15 +11749,7 @@ IF (SEALED .AND. N_ZONE==0) THEN
    READ_ZONE_LINES = .FALSE.
 ENDIF
 
-IF (ANY(EVACUATION_SKIP)) THEN
-   IF (READ_ZONE_LINES) THEN
-      N_ZONE = N_ZONE + N_EVAC_ZONE
-   ELSE
-      ! Check this: Should this be same as above, i.e., n_zone + n_evac_zone
-      ! old: N_ZONE = N_EVAC_ZONE
-      N_ZONE = N_ZONE + N_EVAC_ZONE ! If this works, the inner IF can be deleted
-   ENDIF
-END IF
+IF (ANY(EVACUATION_SKIP)) N_ZONE = N_ZONE + N_EVAC_ZONE
 
 ! Make sure that there are no leak paths to undefined pressure ZONEs
 


### PR DESCRIPTION
A useless IF statement for evacuation in read_zone is removed. Also some small changes to the FDS+Evac manual. This manual update was accidentally together with the read_zone pull request, I am not too experienced GIT user. I should learn, how just to make pull request for the fds source files.