### PR TITLE
FDS Source: Evacuation bug fix for open/close doors

### DIFF
--- a/Source/main.f90
+++ b/Source/main.f90
@@ -3368,7 +3368,7 @@ ENDDO DEVICE_LOOP
 
 ! If a door,entr,exit changes state, save the Smokeview file strings and time of state change
 
-EVAC_ONLY: IF (ANY(EVACUATION_ONLY) .AND. MYID==EVAC_PROCESS) THEN
+EVAC_ONLY: IF (ANY(EVACUATION_ONLY) .AND. MYID==MAX(0,EVAC_PROCESS)) THEN
    I=0  ! Counter for evacuation devices, doors+exits+entrys (evss do not change states)
    DO N=1,N_DOORS
       NM = EVAC_DOORS(N)%IMESH


### PR DESCRIPTION
MYID==EVAC_PROCESS => MYID==MAX(0,EVAC_PROCESS) fix in main.f90 after
the update_devices_2 call.  Now things work for a single process runs also.