### PR TITLE
FDS Source: Evacuation fix for read zone input checks.

### DIFF
--- a/Source/read.f90
+++ b/Source/read.f90
@@ -11831,7 +11831,7 @@ ENDDO
 
 ! If the whole domain lacks on OPEN or PERIODIC boundary, assume it to be one big pressure zone
 
-IF (SEALED .AND. N_ZONE==0 .AND. NMESHES>1) THEN
+IF (SEALED .AND. N_ZONE==0 .AND. (NMESHES-COUNT(EVACUATION_ONLY))>1) THEN
    WRITE(MESSAGE,'(A)')  'ERROR: The domain appears sealed. Specify one or more pressure ZONEs.'
    CALL SHUTDOWN(MESSAGE) ; RETURN
 ENDIF


### PR DESCRIPTION
NMESHES-COUNT(EVACUATION_ONLY) added to the check, if thera are
no zones defined and there are more than one mesh. Now it is
checking that there should be more than one fire mesh.
Evacuation meshes define zones automatically, one zone
for each main evacuation mesh that is read in.