### PR TITLE
FDS build: test intel compiler version when building linux intel debu…

### DIFF
--- a/Build/Scripts/intelmajor_compversion.sh
+++ b/Build/Scripts/intelmajor_compversion.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+#---------------------------------------------
+#                   is_file_installed
+#---------------------------------------------
+
+is_file_installed()
+{
+  local program=$1
+
+  $program -help > prog_version 2>&1
+  notfound=`cat prog_version | head -1 | grep "not found" | wc -l`
+  rm prog_version
+  if [ $notfound -eq 1 ] ; then
+    echo 0
+    exit
+  fi
+  echo 1
+  exit
+}
+
+ifort_installed=`is_file_installed ifort `
+if [ $ifort_installed -eq 0 ]; then
+  echo 0
+  exit
+fi
+
+IFORTMAJORVERSION=`ifort -v |&  awk '{print $3}' | awk -F'.' '{print $1}'`
+echo "\"$IFORTMAJORVERSION\""

--- a/Build/makefile
+++ b/Build/makefile
@@ -48,6 +48,7 @@ ifeq ($(shell echo "check_quotes"),"check_quotes")
 else
 # linux/osx
   INTELMPI_COMPVERSION := $(shell ../Scripts/intelmpi_compversion.sh)
+  INTELMAJOR_COMPVERSION := $(shell ../Scripts/intelmajor_compversion.sh)
   OPENMPI_COMPVERSION := $(shell ../Scripts/openmpi_compversion.sh)
   GNU_COMPVERSION := $(shell ../Scripts/gnu_compversion.sh)
 endif
@@ -183,7 +184,10 @@ impi_intel_linux_64 : obj = fds_impi_intel_linux_64
 impi_intel_linux_64 : setup $(obj_mpi)
 	$(FCOMPL) $(FFLAGS) $(LFLAGS) $(FOPENMPFLAGS) -o $(obj) $(obj_mpi) $(LFLAGSMKL)
 
-impi_intel_linux_64_db : FFLAGS = -m64 -mt_mpi -check -warn noexternals -O0 -auto -WB -traceback -g -fpe0 -fltconsistency -stand:f08 -no-wrap-margin $(GITINFO) $(INTELMPI_COMPINFO) $(FFLAGSMKL_INTEL)
+impi_intel_linux_64_db : FFLAGS = -m64 -mt_mpi -check -O0 -auto -WB -traceback -g -fpe0 -fltconsistency -stand:f08 -no-wrap-margin $(GITINFO) $(INTELMPI_COMPINFO) $(FFLAGSMKL_INTEL)
+ifeq ($(shell expr $(INTELMAJOR_COMPVERSION) \> 19), 1)
+impi_intel_linux_64_db : FFLAGS += -warn noexternals
+endif
 impi_intel_linux_64_db : LFLAGSMKL = $(LFLAGSMKL_INTEL)
 impi_intel_linux_64_db : LFLAGS = -static-intel
 impi_intel_linux_64_db : FCOMPL = mpiifort


### PR DESCRIPTION
…g version. if major version is greater than 19 then add '-warn noexternals' to build options

with changes in the pull requeset, I was able to build the intel linux debug version of fds with both the 19u4 and 20u1 versions of intel fortran