### PR TITLE
Update evac_memory_test0.fds

### DIFF
--- a/Verification/Evacuation/evac_memory_test0.fds
+++ b/Verification/Evacuation/evac_memory_test0.fds
@@ -27,7 +27,7 @@
       SMOKE3D=.TRUE.,
       DT_PART=1.0,
       DT_HRR= 1.0
-      DT_SLCF=1000.0,
+      DT_SLCF=1.0,
       DT_PL3D=1000.0,
       DT_ISOF=1000.0 /
 


### PR DESCRIPTION
When I run this example, I find that 3D smoke cannot be visualized.  Because SMOKE3D=.TRUE., DT_SLCF should be effective.  There is also SLCF defined in the input file.  This example may be improved in several other aspects.  