### PR TITLE
qfds: use n_mpi_proccesses_per_node not ppn in SLURM for mpi processe…

### DIFF
--- a/Utilities/Scripts/qfds.sh
+++ b/Utilities/Scripts/qfds.sh
@@ -751,7 +751,7 @@ else
 
   if [ "$RESOURCE_MANAGER" == "SLURM" ]; then
     QSUB="sbatch -p $queue --ignore-pbs"
-    MPIRUN="srun -N $nodes -n $n_mpi_processes --ntasks-per-node $ppn"
+    MPIRUN="srun -N $nodes -n $n_mpi_processes --ntasks-per-node $n_mpi_processes_per_node"
   fi
 fi
 
@@ -783,7 +783,7 @@ if [ "$queue" != "none" ]; then
 #SBATCH -n $n_mpi_processes
 #SBATCH --nodes=$nodes
 #SBATCH --cpus-per-task=$n_openmp_threads
-#SBATCH --ntasks-per-node=$ppn
+#SBATCH --ntasks-per-node=$n_mpi_processes_per_node
 EOF
 
 if [ "$benchmark" == "yes" ]; then


### PR DESCRIPTION
…s per node

slurm qfds scripts were using the wrong number of mpi processes when multiple openmp threads were input . this PR fixes that