### PR TITLE
FDS Documentation: Change dot fonts for doxygen

### DIFF
--- a/Manuals/Code_Documentation/Doxyfile
+++ b/Manuals/Code_Documentation/Doxyfile
@@ -1582,7 +1582,7 @@ PAPER_TYPE             = a4
 # If left blank no extra packages will be included.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-EXTRA_PACKAGES         =
+EXTRA_PACKAGES         = times
 
 # The LATEX_HEADER tag can be used to specify a personal LaTeX header for the
 # generated LaTeX document. The header should contain everything until the first
@@ -2052,7 +2052,7 @@ DOT_NUM_THREADS        = 0
 # The default value is: Helvetica.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-DOT_FONTNAME           = Helvetica
+DOT_FONTNAME           = Times
 
 # The DOT_FONTSIZE tag can be used to set the size (in points) of the font of
 # dot graphs.


### PR DESCRIPTION
Helvetical font did not compile at puhti.csc.fi computer.