### PR TITLE
FDS User Guide: change SLCF --> BNDF for TERRAIN_CASE section

### DIFF
--- a/Manuals/FDS_User_Guide/FDS_User_Guide.tex
+++ b/Manuals/FDS_User_Guide/FDS_User_Guide.tex
@@ -9894,7 +9894,7 @@ Instead of specifying a plane on which to draw contours of gas temperature, you 
 
 The second method of visualizing data on complex terrain is via a boundary ({\ct BNDF}) file. Specify a solid phase output quantity as you normally would, for example:
 \begin{lstlisting}
-&SLCF QUANTITY='WALL TEMPERATURE' /
+&BNDF QUANTITY='WALL TEMPERATURE' /
 \end{lstlisting}
 and add {\ct TERRAIN\_CASE=T} to the {\ct MISC} line. This will create two boundary files---one of which is the conventional one, and one will be listed as a ``slice'' file that conforms to the terrain.
 


### PR DESCRIPTION
@mcgratta Please double check me on this, but I think this should be BNDF. 

However, as discussed in Issue #9566 , I don't think we need `TERRAIN_CASE`.  Even here in the example of the user guide.  If `TERRAIN_IMAGE=...` then we have a flag to include the terrain image.  If we need a special BNDF for that conforms to the terrain, this should be a flag on the BNDF line, not a MISC parameter.