### PR TITLE
FDS+Evac manual: Updated the numbers in LaTex file

### DIFF
--- a/Manuals/FDS_Evacuation_Guide/FDS+EVAC_Guide.tex
+++ b/Manuals/FDS_Evacuation_Guide/FDS+EVAC_Guide.tex
@@ -3066,8 +3066,8 @@ A speed reduction factor $\gtrsim$0.5 seems to produce more or less
 quite constant flow at the exit door, \emph{i.e.}, at these speed
 reduction values the stairs are feeding the front door fast enough.
 For the case with $\lambda_i$=0.3 the specific flow in FDS+Evac
-simulations is about 1.16~p/s/m and for the case with $\lambda_i$=0.5
-the flow is about 1.30~p/s/m at the final exit door (speed factor
+simulations is about 1.21~p/s/m and for the case with $\lambda_i$=0.5
+the flow is about 1.28~p/s/m at the final exit door (speed factor
 0.75).  The observed flow rate at the final exit door (width 1.07~m)
 was 1.35 p/s in the experiment.
 % Numbers are for fds6.5.3Evac2.5.2
@@ -3095,8 +3095,8 @@ $\gtrsim$0.7 seems to give a good agreement with the observations.
 Note that there exists some queuing at the final exit door opening to
 the street in the experiment and this is also seen in the simulation
 results, when the speed reduction parameter is not too low.  For the
-case with $\lambda_i$=0.3 the specific flow is about 1.17~p/s/m and
-for the case with $\lambda_i$=0.5 the flow is about 1.30~p/s/m at the
+case with $\lambda_i$=0.3 the specific flow is about 1.22~p/s/m and
+for the case with $\lambda_i$=0.5 the flow is about 1.27~p/s/m at the
 final exit door (speed factor 0.75).  Similar flows were also obtained
 when using the simple staircase model (type 1).  When a speed
 reduction factor $\gtrsim$0.7 is used seems to produce more or less
@@ -3116,8 +3116,8 @@ $\gtrsim$0.6 seems to give a good agreement with the observations.
 Note that there exists some queuing at the final exit door opening to
 the street in the experiment and this is also seen in the simulation
 results, when the speed reduction parameter is not too low.  For the
-case with $\lambda_i$=0.3 the specific flow is about 1.18~p/s/m and
-for the case with $\lambda_i$=0.5 the flow is about 1.40~p/s/m at the
+case with $\lambda_i$=0.3 the specific flow is about 1.19~p/s/m and
+for the case with $\lambda_i$=0.5 the flow is about 1.39~p/s/m at the
 final exit door (speed factor 0.75).  Similar flows were also obtained
 when using the other staircase models.  When a speed reduction factor
 $\gtrsim$0.6 is used seems to produce more or less quite constant flow
@@ -3377,8 +3377,8 @@ using FDS+Evac version 2.6.0.
   and standard input.  (An advanced user of these codes might be able
   to get different results by using some additional features.)  The
   results of FDS+Evac model look more realistic.  The calculated
-  specific flows (1/p/m) are: Simulex 0.47, Exodus 0.69, FDS+Evac 1.23
-  ($\lambda_i=0.3$), and 1.57 ($\lambda_i=0.5$).
+  specific flows (1/p/m) are: Simulex 0.47, Exodus 0.69, FDS+Evac 1.24
+  ($\lambda_i=0.3$), and 1.58 ($\lambda_i=0.5$).
   % Numbers are for fds6.5.3Evac2.5.2
   
   In Figure~\ref{Fig_AssemblyResults} also shown are the results of
@@ -3387,7 +3387,7 @@ using FDS+Evac version 2.6.0.
   wall of the room.  In this case, the agreement between the different
   evacuation programmes is much better.  The calculated specific flows
   (1/p/m) are: Simulex 1.59, Exodus 1.95, FDS+Evac 1.62
-  ($\lambda_i=0.3$), and 2.01 ($\lambda_i=0.5$).
+  ($\lambda_i=0.3$), and 2.02 ($\lambda_i=0.5$).
   % Numbers are for fds6.5.3Evac2.5.2
 
 %


### PR DESCRIPTION
Previous commit hat the new (6.7.6/2.6.0) version results, but the numbers for the (specific) flows in the source was not updated. Now they are also 6.7.6 numbers (i.e., same results as the figures).