### PR TITLE
FDS+Evac Source: Small fix to evac mc mode smv file write

### DIFF
--- a/Source/main.f90
+++ b/Source/main.f90
@@ -963,6 +963,10 @@ IF (PRES_METHOD == 'GLMAT') CALL FINISH_GLMAT_SOLVER_H
 
 IF (CC_IBM) CALL FINISH_CCIBM
 
+! Finish the smv file (fire+evacuation results) write for the evacuation MC mode
+
+IF (EVACUATION_MC_MODE .AND. .NOT.EVACUATION_DRILL) CALL FINISH_EVACUATION_SMV
+
 ! Stop the calculation
 
 CALL END_FDS


### PR DESCRIPTION
Now the evacuation mc mode (using fed) writes the smokeview file
as CHID_evmc.smv. It begins with the fire smv file copied up to
the point where the mesh information ends (last CVENT). The
NMESHES is changed to fire+evacuaion meshes. After this, the
evaucuation stuff is written to the CHID_evmc.smv file. Just
before the end of the run, the rest of the fire smv file (strings)
is appended to the end of the CHID_evmc.file.