### PR TITLE
FDS+Evac Source: evac.f90 changed for the "no smoke" criterion for doors

### DIFF
--- a/Source/evac.f90
+++ b/Source/evac.f90
@@ -1522,7 +1522,7 @@ CONTAINS
       ! TDET_SMOKE_DENS: Smoke is detected, when its density is larger than, e.g. 1 mg/m3
       !                  Default is no detection due to smoke.
       TDET_SMOKE_DENS = -999.9_EB  !
-      FED_DOOR_CRIT   = -100.0_EB ! Which doors are 'smoke free' Evac >= 2.2.2
+      FED_DOOR_CRIT   = -1000.0_EB ! Which doors are 'smoke free' Evac >= 2.2.2
       GROUP_DENS      = 0.0_EB
       SMOKE_MIN_SPEED = -99999._EB
       SMOKE_MIN_SPEED_FACTOR = -99999._EB
@@ -16218,7 +16218,7 @@ CONTAINS
           PP_see_door = PP_see_door .OR. (PP_see_doorXB .AND. PP_correct_side)
 
           FED_max_Door(i) = max_fed
-          K_ave_Door(i) = MAX(ave_K,0.5_EB*ABS(FED_DOOR_CRIT)) ! no divisions by zero
+          K_ave_Door(i) = MAX(ave_K,K_ave_Door(i)) ! no divisions by zero
 
           ! Note: a DOOR is not counted as visible door, if it does not have an
           ! EXIT_SIGN, unless it is already been a target door for this agent/group.
@@ -16310,7 +16310,7 @@ CONTAINS
              IF (FED_DOOR_CRIT >= TWO_EPSILON_EB) THEN
                 L2_tmp = FED_max_Door(i) * SQRT((x1_old-x_o)**2 + (y1_old-y_o)**2)/Speed
              ELSE
-                L2_tmp = K_ave_Door(i)
+                L2_tmp = K_ave_Door(i)*SQRT((x1_old-x_o)**2 + (y1_old-y_o)**2)
              END IF
              IF (i_o == i_old_ffield) L2_tmp = FAC_DOOR_OLD*L2_tmp
              IF (ABS(FAC_DOOR_QUEUE) >= TWO_EPSILON_EB) THEN
@@ -16345,10 +16345,10 @@ CONTAINS
                 ELSE
                    ! Check that visibility > 0.5*distance to the door
                    L2_tmp = SQRT((x1_old-x_o)**2+(y1_old-y_o)**2)*0.5_EB/(3.0_EB/K_ave_Door(i))
-                   L2_tmp2 = K_ave_Door(i)  ! no smoke criteria
+                   L2_tmp2 = K_ave_Door(i)*SQRT((x1_old-x_o)**2+(y1_old-y_o)**2)  ! no smoke criteria
                 END IF
-                L2_tmp  = FAC_DOOR_OLD2*L2_tmp
-                L2_tmp2 = FAC_DOOR_OLD *L2_tmp2
+                L2_tmp  = FAC_DOOR_OLD2*L2_tmp  ! too much smoke criteria, i.e., the door can not be used
+                L2_tmp2 = FAC_DOOR_OLD *L2_tmp2 ! no smoke criteria
                 IF (HR%GROUP_ID < 0 .AND. L2_tmp2 >= ABS(FED_DOOR_CRIT)) THEN ! This is not working for groups yet nor entr agents
                    ! The present (known) target door has some smoke, record this information for later use.
                    ! If there is too much smoke => set i_nodes = 0 for this door, is not anymore known door
@@ -16404,7 +16404,7 @@ CONTAINS
                    ! Now L1 norm for non-visible doors (21.9.2010)
                    L2_tmp = FED_max_Door(i)*(ABS(x1_old-x_o) + ABS(y1_old-y_o))/Speed
                 ELSE
-                   L2_tmp = K_ave_Door(i)
+                   L2_tmp = K_ave_Door(i)*(ABS(x1_old-x_o) + ABS(y1_old-y_o))
                 END IF
                 IF (i_o == i_old_ffield) L2_tmp = FAC_DOOR_OLD*L2_tmp
                 ! T_tmp  = SQRT((x_o-x1_old)**2 + (y_o-y1_old)**2)
@@ -16453,7 +16453,7 @@ CONTAINS
                    IF (FED_DOOR_CRIT >= TWO_EPSILON_EB) THEN
                       L2_tmp = FED_max_Door(i)*SQRT((x1_old-x_o)**2 + (y1_old-y_o)**2)/Speed
                    ELSE
-                      L2_tmp = K_ave_Door(i)
+                      L2_tmp = K_ave_Door(i)*SQRT((x1_old-x_o)**2 + (y1_old-y_o)**2)
                    END IF
                    IF (i_o == i_old_ffield) L2_tmp = FAC_DOOR_OLD*L2_tmp
                    T_tmp  = SQRT((x_o-x1_old)**2 + (y_o-y1_old)**2)


### PR DESCRIPTION
The "no smoke" with visibility criterion is now including the distance to the door/exit. The test is now K_ave_agent_to_door*distance_toDoor < K_criterion that is user (default 3/1000) input. The previous version had K_default 3/100, so the new criterion is the same, if the agent is 10 m away from the door. Why this change was done? Without it, an agent was changing the target door even, if it was really close to it.