### PR TITLE
FDS+Evac source: One line deleted (evac.f90)

### DIFF
--- a/Source/evac.f90
+++ b/Source/evac.f90
@@ -5645,7 +5645,6 @@ CONTAINS
           ELSE
              OPEN (LU_EVACFED,file=FN_EVACFED,form='unformatted', status='old')
              READ (LU_EVACFED,Iostat=ios) ntmp1
-             N_FIRE_MESHES_IN_FED = ntmp2
              IF (ios/=0) THEN
                 WRITE(MESSAGE,'(A)') 'ERROR: Init Evac Dumps: FED READ ERROR'
                 CLOSE (LU_EVACFED)


### PR DESCRIPTION
There was one extra line that did not do anything. But it generated
an error message (uninitialized variable used), when compiled
in debug mode.