### PR TITLE
FDS Source: special treatment of corner edges

### DIFF
--- a/Source/velo.f90
+++ b/Source/velo.f90
@@ -1981,7 +1981,7 @@ EDGE_LOOP: DO IE=1,N_EDGES
 
          IF (IWM==0 .AND. IWP==0) CYCLE ORIENTATION_LOOP
 
-         ! If the edge is a corner, recorder this so we do not overwrite VEL_GHOST
+         ! If the edge is a corner, note this so we do not overwrite VEL_GHOST
 
          IF (IWM==0 .OR. IWP==0) CORNER_EDGE=.TRUE.
 

--- a/Source/velo.f90
+++ b/Source/velo.f90
@@ -2308,15 +2308,12 @@ EDGE_LOOP: DO IE=1,N_EDGES
                      ELSE
                         CALL WALL_MODEL(SLIP_COEF,U_TAU,Y_PLUS,MU_WALL/RHO_WALL,SF%ROUGHNESS,0.5_EB*DXX(ICD),VEL_GAS-VEL_T)
                      ENDIF
-                     ! SLIP_COEF = -1, no slip, VEL_GHOST=-VEL_GAS
-                     ! SLIP_COEF =  1, free slip, VEL_GHOST=VEL_T
-                     ! Notes: This curious definition of VEL_GHOST was chosen to improve the treatment of edge vorticity
-                     ! especially at corners.  The stress still comes directly from U_TAU (i.e., the WALL_MODEL).
-                     ! DUIDXJ is used to compute the vorticity at the edge.  Without this definition, the ribbed_channel
-                     ! test series does not achieve the correct MEAN or RMS profiles without very high grid resolution.
-                     VEL_GHOST = VEL_T + 0.5_EB*(SLIP_COEF-1._EB)*(VEL_GAS-VEL_T)
+                     ! SLIP_COEF = -1, no slip, VEL_GHOST=2*VEL_T-VEL_GAS
+                     ! SLIP_COEF =  1, free slip, VEL_GHOST=VEL_GAS
+
+                     IF (.NOT.CORNER_EDGE) VEL_GHOST = VEL_T + SLIP_COEF*(VEL_GAS-VEL_T)
                      DUIDXJ(ICD_SGN) = I_SGN*(VEL_GAS-VEL_GHOST)/DXX(ICD)
-                     MU_DUIDXJ(ICD_SGN) = RHO_WALL*U_TAU**2 * SIGN(1._EB,I_SGN*(VEL_GAS-VEL_T))
+                     MU_DUIDXJ(ICD_SGN) = RHO_WALL*U_TAU**2 * SIGN(1._EB,DUIDXJ(ICD_SGN))
                      ALTERED_GRADIENT(ICD_SGN) = .TRUE.
 
                   CASE (BOUNDARY_FUEL_MODEL_BC) BOUNDARY_CONDITION


### PR DESCRIPTION
This addresses Issue #10075.  Test with the attached input file.  Note that use of CONSMAG for the near wall model is what suppresses the jets that were the original complaint on the issue.  This PR addresses the backward velocity on top of the OBST.

[angle_45a.fds.txt](https://github.com/firemodels/fds/files/7796497/angle_45a.fds.txt)
