### PR TITLE
Added 'Github Actions' workers for validating PRs.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,69 @@
+name: github-linux
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  
+jobs:
+  linux-intel-intelmpi:
+    # debug build on ubuntu using ifort and intelmpi
+    # based on https://github.com/oneapi-src/oneapi-ci
+    
+    name: linux intel intelmpi
+    runs-on: [ubuntu-latest]
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: setup apt repository
+      run: |
+        # oneapi-ci/scripts/setup_apt_repo_linux.sh
+        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/oneAPI.list" -o APT::Get::List-Cleanup="0"
+    - name: collect versioned dependencies of apt packages
+      run : |
+        # oneapi-ci/scripts/apt_depends.sh
+        apt-cache depends intel-oneapi-compiler-fortran \
+                          intel-oneapi-mpi-devel \
+                          intel-oneapi-mkl-devel | tee dependencies.txt
+    - name: cache install
+      id: cache-install
+      uses: actions/cache@v2
+      with:
+        path: /opt/intel/oneapi
+        key: install-${{ hashFiles('**/dependencies.txt') }}
+    - name: install
+      if: steps.cache-install.outputs.cache-hit != 'true'
+      run: |
+        # oneapi-ci/scripts/install_linux_apt.sh
+        sudo apt-get install -y intel-oneapi-compiler-fortran \
+                                intel-oneapi-mpi-devel \
+                                intel-oneapi-mkl-devel
+        sudo apt-get clean
+    - name: build
+      run: |
+        source /opt/intel/oneapi/setvars.sh
+        cd ./Build/impi_intel_linux_64_db
+        sh ./make_fds.sh
+        ./fds_impi_intel_linux_64_db
+
+
+  linux-gnu-openmpi:
+    # debug build on ubuntu using gfortran and openmpi
+    
+    name: linux gnu openmpi
+    runs-on: [ubuntu-latest]
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: install
+      run: |
+        sudo apt-get install openmpi-bin
+    - name: build
+      run: |
+        cd ./Build/mpi_gnu_linux_64_db
+        sh ./make_fds.sh
+        ./fds_mpi_gnu_linux_64_db


### PR DESCRIPTION
This PR proposes to validate pull requests before merging as mentioned in https://github.com/firemodels/fds/issues/9468#issuecomment-840276204.

On each push or pull request, the github workers will compile a debug version of FDS on ubuntu using the most recent gfortran and Intel OneAPI Fortran compilers. This way, you make sure that your new code works on all supported compilers, and ensure that contributions of foreign users conform to your standards.

The 'Github Actions' service is free for public repositories on github, and will therefore be available for any forked repository. On my fork of FDS, the check with `gfortran` and `ifort` takes about 3 minutes. You might need to activate this feature first as described [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository).

However, this feature is not a competitor to your `firebot` as there is no in-depth validation of your code. You should rather see it as an additional layer in your continous integration process to find problems before they are even merged into the master branch.

---

In the future, you might also consider to check to compile your code on different platforms (OSX and Windows), but since you mainly support GNU and Intel compilers (which are checked with the Linux scripts), I don't think it will be necessary. I tried to build FDS with Intel compilers on both OSX and Windows on [this branch](https://github.com/marcfehling/fds/tree/github-actions), but there are still issues I couldn't resolve.

Another possible extension would be to check for older compiler versions. Further, one can enhance these workers to also perform basic tests to ensure that FDS still produces similar results after applying the proposed patch.

---

As a next step for a separate PR, I would like to add the `Wall` flag. This way, the github workers will complain if your patch causes a warning and inform you about it. This is particularly useful as different compilers indicate different warnings. Fixing compiler warnings early helps making your code more robust.

For this, I would like to ask you if there is a way to easily add additional flags to your Makefile. The only way I found so far is to entirely override your `FFLAGS` variable which works, but then you would also need to update the github actions script when you change them. Is there are simpler way? For example, how do you add flags if you compile FDS on supercomputers which might require specific compiler options?

I might need your help in fixing the warnings we would encounter as I am no expert in Fortran programming.