### PR TITLE
Matlab: add error check for heated_channel cases

### DIFF
--- a/Utilities/Matlab/scripts/heated_channel.m
+++ b/Utilities/Matlab/scripts/heated_channel.m
@@ -126,6 +126,18 @@ for i = [1,2,3,4]
         set(groot,'CurrentFigure',f2);
         hfig2(1)=semilogx(zp,Tp,'ksq-');
     end
+
+    switch i
+        case 1; err(i) = abs( mean(Tp)-mean(Tp_mean_Pr0p10,'omitnan') )/mean(Tp_mean_Pr0p10,'omitnan');
+        case 2; err(i) = abs( mean(Tp)-mean(Tp_mean_Pr0p71,'omitnan') )/mean(Tp_mean_Pr0p71,'omitnan');
+        case 3; err(i) = abs( mean(up)-mean(up_mean,'omitnan')        )/mean(up_mean,'omitnan');
+        case 4; err(i) = abs( mean(Tp)-mean(Tp_mean_Pr2p00,'omitnan') )/mean(Tp_mean_Pr2p00,'omitnan');
+    end
+
+    if err(i)>0.2
+        disp(['Matlab Warning: heated_channel case ',num2str(i),' out of tolerance'])
+    end
+
 end
 
 if skip_case


### PR DESCRIPTION
This PR is going to break firebot tonight, but firebot should not have passed lately, it's just that this case was not being flagged.  We think we've solved the problem, and we are rerunning the cases.