### PR TITLE
Fix errors in serial version and inseparable Poisson matrix generation for solids along interfaces

### DIFF
--- a/Source/scrc.f90
+++ b/Source/scrc.f90
@@ -5498,7 +5498,7 @@ END SUBROUTINE SCARC_VECTOR_INIT
 ! --------------------------------------------------------------------------------------------------------------
 SUBROUTINE SCARC_MATVEC_PRODUCT(NV1, NV2, NL)
 INTEGER, INTENT(IN) :: NV1, NV2, NL           
-REAL(EB) :: TNOW, V2O
+REAL(EB) :: TNOW
 INTEGER :: NM, IC, JC, ICOL
 #ifdef WITH_MKL
 EXTERNAL :: DAXPBY, DAXPY
@@ -5530,7 +5530,6 @@ MESHES_LOOP: DO NM = LOWER_MESH_INDEX, UPPER_MESH_INDEX
       DO IC = 1, G%NC
          ICOL = A%ROW(IC)                                                ! diagonal entry
          JC   = A%COL(ICOL)
-         V2O = V2(IC)
          V2(IC) = A%VAL(ICOL)* V1(JC)
          DO ICOL = A%ROW(IC)+1, A%ROW(IC+1)-1                            ! subdiagonal entries
             JC = A%COL(ICOL)


### PR DESCRIPTION
This PR corrects the errors addressed in Issue #10357 concerning
- the serial version with regard to the activation of obstructions 
- the use of density values in the generation of the inseparable Poisson matrix with regard to obstructions adjacent to an interface