### PR TITLE
testmpi: change osx build directory and associated makefile entry to …

### DIFF
--- a/Utilities/test_mpi/makefile
+++ b/Utilities/test_mpi/makefile
@@ -59,11 +59,11 @@ impi_intel_linux: $(obj_mpi)
 
 # OSX
 
-mpi_intel_osx: FFLAGS = -m64 -O2 -traceback -no-wrap-margin
-mpi_intel_osx: LFLAGS = -static-intel
-mpi_intel_osx: FCOMPL = mpifort
-mpi_intel_osx: obj = test_mpi
-mpi_intel_osx: $(obj_mpi)
+ompi_intel_osx: FFLAGS = -m64 -O2 -traceback -no-wrap-margin
+ompi_intel_osx: LFLAGS = -static-intel
+ompi_intel_osx: FCOMPL = mpifort
+ompi_intel_osx: obj = test_mpi
+ompi_intel_osx: $(obj_mpi)
 	$(FCOMPL) -o $(obj) $(FFLAGS) $(LFLAGS) $(obj_mpi)
 
 #*** Clean Target to remove Object and Module files ***

--- a/Utilities/test_mpi/opmi_intel_osx/make_test_mpi.sh
+++ b/Utilities/test_mpi/opmi_intel_osx/make_test_mpi.sh
@@ -2,4 +2,4 @@
 
 echo Building with OpenMPI
 make -f ../makefile clean
-make VPATH=".." -f ../makefile mpi_intel_osx
+make VPATH=".." -f ../makefile ompi_intel_osx


### PR DESCRIPTION
…ompi_intel_osx (to be consistent with fds build directories)