### PR TITLE
FDS Validation: USFS Deep Fuel Beds added make_Run_All.py

### DIFF
--- a/Validation/USFS_Deep_Fuel_Beds/FDS_Input_Files/Build_Input_Files/Run_All_base.txt
+++ b/Validation/USFS_Deep_Fuel_Beds/FDS_Input_Files/Build_Input_Files/Run_All_base.txt
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# This script runs a set of Validation Cases on a Linux machine with a batch queuing system.
+# See the file Validation/Common_Run_All.sh for more information.
+export SVNROOT=`pwd`/../..
+source $SVNROOT/Validation/Common_Run_All.sh
+
+# good burn: 136, 114, marginal burn: 41,80 no burn: 30,60
+

--- a/Validation/USFS_Deep_Fuel_Beds/FDS_Input_Files/Build_Input_Files/make_Run_All.py
+++ b/Validation/USFS_Deep_Fuel_Beds/FDS_Input_Files/Build_Input_Files/make_Run_All.py
@@ -1,0 +1,20 @@
+# 7/18/2022 Noelle Crump, to generate Run_All.sh 
+# this one is for USFS Deep Fuel Beds
+
+import shutil
+import os
+from os import listdir
+
+input_file_list = [f for f in listdir('../') if f[-4:] == '.fds']
+shutil.copy('Run_All_base.txt','Run_All.sh')
+forestring = '$QFDS $DEBUG $QUEUE -p 16 -d $INDIR '
+
+f = open('Run_All.sh', 'a')
+for filename in input_file_list:
+    f.write(forestring + filename +'\n')
+f.write('\necho FDS cases submitted')
+f.close()
+
+# Move Run_All.sh  files up to Case Folder
+os.replace("Run_All.sh", "../../Run_All.sh")
+os.system('chmod +x  ../../Run_All.sh')


### PR DESCRIPTION
`make_Run_All.py` builds a `Run_All.sh` file from all the .fds files in the `FDS_Input_Files` directory by copying `Run_All_base.txt` and writing each files to a new line. It then moves the newly made `Run_All.sh` file to the case directory (in this case, `USFS_Deep_Fuel_Beds`) and then gives that file executable permissions. This script does not work if all the input files are not in the `FDS_Input_Files` directory, and may create a bad Run_All script if any .fds file that is not an input file to be run is in the `FDS_Input_Files` directory.