### PR TITLE
Added Windows worker (no cache).

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,71 @@
+name: github-windows
+
+
+on:
+  push:
+    paths:
+    - .github/**
+    - Build/**
+    - Source/**
+  pull_request:
+    paths:
+    - .github/**
+    - Build/**
+    - Source/**
+
+
+concurrency:
+  group: ${{ github.event_name }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+
+permissions:
+  contents: read
+
+
+env:
+  # update URLs for Intel according to:
+  #   https://github.com/oneapi-src/oneapi-ci/blob/master/.github/workflows/build_all.yml
+
+  WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18674/w_BaseKit_p_2022.2.0.252_offline.exe
+  WINDOWS_BASEKIT_COMPONENTS: intel.oneapi.win.mkl.devel
+  WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18680/w_HPCKit_p_2022.2.0.173_offline.exe
+  WINDOWS_HPCKIT_COMPONENTS: intel.oneapi.win.ifort-compiler:intel.oneapi.win.mpi.devel
+
+
+jobs:
+  windows-intel-intelmpi:
+    # debug build on windows using ifort with intelmpi and mkl
+    # based on https://github.com/oneapi-src/
+
+    name: windows intel intelmpi
+    runs-on: [windows-2022]
+    defaults:
+      run:
+        shell: cmd
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: install oneapi mkl
+      run: |
+        # oneapi-ci/scripts/install_windows.bat
+        curl.exe --output %TEMP%\webimage_base.exe --url %WINDOWS_BASEKIT_URL% --retry 5 --retry-delay 5
+        start /b /wait %TEMP%\webimage_base.exe -s -x -f webimage_base_extracted --log extract_base.log
+        del %TEMP%\webimage_base.exe
+        webimage_base_extracted\bootstrapper.exe -s --action install --components=%WINDOWS_BASEKIT_COMPONENTS% --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 --log-dir=.
+        rd /s/q "webimage_base_extracted"
+    - name: install oneapi compilers
+      run: |
+        # oneapi-ci/scripts/install_windows.bat
+        curl.exe --output %TEMP%\webimage_hpc.exe --url %WINDOWS_HPCKIT_URL% --retry 5 --retry-delay 5
+        start /b /wait %TEMP%\webimage_hpc.exe -s -x -f webimage_hpc_extracted --log extract_hpc.log
+        del %TEMP%\webimage_hpc.exe
+        webimage_hpc_extracted\bootstrapper.exe -s --action install --components=%WINDOWS_HPCKIT_COMPONENTS% --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 --log-dir=.
+        rd /s/q "webimage_hpc_extracted"
+    - name: build
+      run: |
+        # oneapi-ci/scripts/build_windows.bat
+        call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
+        cd Build\impi_intel_win_db
+        call make_fds.bat
+        fds_impi_intel_win_db.exe


### PR DESCRIPTION
This patch adds another worker to 'Github Actions' which compiles FDS with ifort, impi, and MKL on Windows systems.

The worker takes about half an hour.

I couldn't get the cache to work yet because, for some reason, Intel doesn't initialize its modules correctly after the cache is restored. I suspect that the Intel installers write something into the Windows registry that I need to add manually.

I will get in touch with the Intel support about the issue.