### PR TITLE
Enable cache for Windows worker.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -24,9 +24,8 @@ permissions:
 
 
 env:
-  # update URLs for Intel according to:
-  #   https://github.com/oneapi-src/oneapi-ci/blob/master/.github/workflows/build_all.yml
-
+  # update urls for oneapi packages according to
+  # https://github.com/oneapi-src/oneapi-ci/blob/master/.github/workflows/build_all.yml
   WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18674/w_BaseKit_p_2022.2.0.252_offline.exe
   WINDOWS_BASEKIT_COMPONENTS: intel.oneapi.win.mkl.devel
   WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/18680/w_HPCKit_p_2022.2.0.173_offline.exe
@@ -36,36 +35,55 @@ env:
 jobs:
   windows-intel-intelmpi:
     # debug build on windows using ifort with intelmpi and mkl
-    # based on https://github.com/oneapi-src/
+    # based on https://github.com/oneapi-src/oneapi-ci
 
     name: windows intel intelmpi
-    runs-on: [windows-2022]
+    runs-on: [windows-latest]
     defaults:
       run:
         shell: cmd
 
     steps:
     - uses: actions/checkout@v3
+
+      # install oneapi components from web installer based on
+      # oneapi-ci/scripts/install_windows.bat
+    - name: cache install oneapi
+      id: cache-install
+      uses: actions/cache@v3
+      with:
+        path: C:\Program Files (x86)\Intel\oneAPI\
+        key: install-${{ env.WINDOWS_BASEKIT_URL }}-${{ env.WINDOWS_BASEKIT_COMPONENTS }}-${{ env.WINDOWS_HPCKIT_URL }}-${{ env.WINDOWS_HPCKIT_COMPONENTS }}
     - name: install oneapi mkl
+      if: steps.cache-install.outputs.cache-hit != 'true'
       run: |
-        # oneapi-ci/scripts/install_windows.bat
         curl.exe --output %TEMP%\webimage_base.exe --url %WINDOWS_BASEKIT_URL% --retry 5 --retry-delay 5
         start /b /wait %TEMP%\webimage_base.exe -s -x -f webimage_base_extracted --log extract_base.log
         del %TEMP%\webimage_base.exe
         webimage_base_extracted\bootstrapper.exe -s --action install --components=%WINDOWS_BASEKIT_COMPONENTS% --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 --log-dir=.
         rd /s/q "webimage_base_extracted"
-    - name: install oneapi compilers
+    - name: install oneapi compiler, mpi
+      if: steps.cache-install.outputs.cache-hit != 'true'
       run: |
-        # oneapi-ci/scripts/install_windows.bat
         curl.exe --output %TEMP%\webimage_hpc.exe --url %WINDOWS_HPCKIT_URL% --retry 5 --retry-delay 5
         start /b /wait %TEMP%\webimage_hpc.exe -s -x -f webimage_hpc_extracted --log extract_hpc.log
         del %TEMP%\webimage_hpc.exe
         webimage_hpc_extracted\bootstrapper.exe -s --action install --components=%WINDOWS_HPCKIT_COMPONENTS% --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 --log-dir=.
         rd /s/q "webimage_hpc_extracted"
-    - name: build
+
+      # github-actions does not cache windows symlinks, so we need to specify the version of each component explicitly
+      # https://www.intel.com/content/www/us/en/develop/documentation/oneapi-programming-guide/top/oneapi-development-environment-setup/use-the-setvars-script-with-windows/use-a-config-file-for-setvars-bat-on-windows.html
+      # https://oneapi-src.github.io/oneapi-ci/
+    - name: specify oneapi version
       run: |
-        # oneapi-ci/scripts/build_windows.bat
-        call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
+        (
+          echo compiler=2022.1.0
+          echo mkl=2022.1.0
+          echo mpi=2021.6.0
+        ) > oneapi_config.txt
+    - name: build fds
+      run: |
+        call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat" --config="oneapi_config.txt"
         cd Build\impi_intel_win_db
         call make_fds.bat
         fds_impi_intel_win_db.exe


### PR DESCRIPTION
'Github Actions' does not cache Windows symlinks, so we need to specify the version of each oneAPI component explicitly.