### PR TITLE
github actions: added another openmpi package to linux

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -88,7 +88,7 @@ jobs:
     - name: install openmpi
       run: |
         sudo apt-get update
-        sudo apt-get install openmpi-bin
+        sudo apt-get install libopenmpi-dev openmpi-bin
 
       # install oneapi components from apt repository based on
       # oneapi-ci/scripts/setup_apt_repo_linux.sh


### PR DESCRIPTION
This should fix the warnings on the `linux-gnu-openmpi` worker:
```
Nonexistent include directory ‘/usr/lib/x86_64-linux-gnu/openmpi/lib/../../fortran/gfortran-mod-15/openmpi’
```