### PR TITLE
github-actions: update intel oneapi kits to 2023.1.0, update openmpi to 4.1.5

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -27,11 +27,11 @@ env:
   # update urls for oneapi and openmpi packages according to
   # https://github.com/oneapi-src/oneapi-ci/blob/master/.github/workflows/build_all.yml
   # https://open-mpi.org/software/ompi/
-  MACOS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/19080/m_BaseKit_p_2023.0.0.25441_offline.dmg
+  MACOS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2516a0a0-de4d-4f3d-9e83-545b32127dbb/m_BaseKit_p_2023.1.0.45568_offline.dmg
   MACOS_BASEKIT_COMPONENTS: intel.oneapi.mac.mkl.devel
-  MACOS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/19086/m_HPCKit_p_2023.0.0.25440_offline.dmg
+  MACOS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/a99cb1c5-5af6-4824-9811-ae172d24e594/m_HPCKit_p_2023.1.0.44543_offline.dmg
   MACOS_HPCKIT_COMPONENTS: intel.oneapi.mac.cpp-compiler:intel.oneapi.mac.ifort-compiler
-  OPENMPI_URL: https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.4.tar.gz
+  OPENMPI_URL: https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.5.tar.gz
 
 
 jobs:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,9 +26,9 @@ permissions:
 env:
   # update urls for oneapi packages according to
   # https://github.com/oneapi-src/oneapi-ci/blob/master/.github/workflows/build_all.yml
-  WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/19078/w_BaseKit_p_2023.0.0.25940_offline.exe
+  WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/c961e083-5685-4f0b-ada5-c6cf16f561dd/w_BaseKit_p_2023.1.0.47256_offline.exe
   WINDOWS_BASEKIT_COMPONENTS: intel.oneapi.win.mkl.devel
-  WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/irc_nas/19085/w_HPCKit_p_2023.0.0.25931_offline.exe
+  WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2a13d966-fcc5-4a66-9fcc-50603820e0c9/w_HPCKit_p_2023.1.0.46357_offline.exe
   WINDOWS_HPCKIT_COMPONENTS: intel.oneapi.win.ifort-compiler:intel.oneapi.win.mpi.devel
 
 
@@ -77,9 +77,9 @@ jobs:
     - name: specify oneapi version
       run: |
         (
-          echo compiler=2023.0.0
-          echo mkl=2023.0.0
-          echo mpi=2021.8.0
+          echo compiler=2023.1.0
+          echo mkl=2023.1.0
+          echo mpi=2021.9.0
         ) > oneapi_config.txt
     - name: build fds debug
       run: |


### PR DESCRIPTION
Follow up to #11373.

The CI will take a while for the next pull request as caches need to be rebuild. But you will be back to the 5 minute long checks after that is done.