### PR TITLE
github-actions: update intel workflow

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,8 +39,8 @@ jobs:
       # oneapi-ci/scripts/install_linux_apt.sh
     - name: setup apt repository
       run: |
-        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
-        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
         echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
         sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/oneAPI.list" -o APT::Get::List-Cleanup="0"
     - name: collect versioned dependencies of apt packages

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,15 +34,15 @@ jobs:
     - uses: actions/checkout@v4
 
       # install oneapi components from apt repository based on
+      # https://www.intel.com/content/www/us/en/docs/oneapi/installation-guide-linux/2023-2/apt.html
       # oneapi-ci/scripts/setup_apt_repo_linux.sh
       # oneapi-ci/scripts/apt_depends.sh
       # oneapi-ci/scripts/install_linux_apt.sh
     - name: setup apt repository
       run: |
-        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
-        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
-        echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-        sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/oneAPI.list" -o APT::Get::List-Cleanup="0"
+        wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+        echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt-get update
     - name: collect versioned dependencies of apt packages
       run : |
         apt-cache depends intel-oneapi-compiler-fortran \


### PR DESCRIPTION
Closes #12162.

The oneapi workflow works again, without us having to change anything on our side.

However, some minor maintenance is necessary to make the process future-proof.