### PR TITLE
set limits max velocity in plot 3d dump to prevent float overflow in debug builds

### DIFF
--- a/Source/dump.f90
+++ b/Source/dump.f90
@@ -6072,9 +6072,9 @@ IF (PLOT3D) THEN
    DO K = 0, KBAR
       DO J = 0, JBAR
          DO I = 0, IBAR
-           UVEL = QQ(I,J,K,2)
-           VVEL = QQ(I,J,K,3)
-           WVEL = QQ(I,J,K,4)
+           UVEL = MAX(MIN(QQ(I,J,K,2),1E6_FB),-1E6_FB)
+           VVEL = MAX(MIN(QQ(I,J,K,3),1E6_FB),-1E6_FB)
+           WVEL = MAX(MIN(QQ(I,J,K,4),1E6_FB),-1E6_FB)
            VEL = SQRT(UVEL*UVEL + VVEL*VVEL + WVEL*WVEL)
            PLOT3D_MIN = MIN(PLOT3D_MIN,VEL)
            PLOT3D_MAX = MAX(PLOT3D_MAX,VEL)


### PR DESCRIPTION
When FDS encounters a numerical instability, it is currently possible for the velocity magnitude in the PLOT3D data dumps to overflow the maximum value of REAL(FB). This results in an earlier crash in debug builds which does not occur in release. This PR sets a cap on UVEL, VVEL, and WVEL in the PLOT3D dump to avoid the float overflow.