### PR TITLE
small qfds fixes for PBS

### DIFF
--- a/Utilities/Scripts/qfds.sh
+++ b/Utilities/Scripts/qfds.sh
@@ -132,12 +132,7 @@ dir=.
 benchmark=no
 showinput=0
 exe=
-
-if [ "$RESOURCE_MANAGER" == "SLURM" ]; then
-   walltime=99-99:99:99
-else
-   walltime=999:99:99
-fi
+walltime=99-99:99:99
 
 if [ $# -lt 1 ]; then
   usage
@@ -186,6 +181,9 @@ case $OPTION  in
    ;;
   P)
    RESOURCE_MANAGER="PBS/Torque"
+   if [ "$walltime" == "99-99:99:99" ]; then
+     walltime=999:99:99
+   fi
    ;;
   p)
    n_mpi_processes="$OPTARG"
@@ -389,8 +387,7 @@ cat << EOF >> $scriptfile
 #PBS -e $outerr
 #PBS -o $outlog
 #PBS -q $queue
-#PBS -l ppn=$n_mpi_processes
-#PBS -l nodes=$nodes
+#PBS -l nodes=$nodes:ppn=$n_mpi_processes
 #PBS -l walltime=$walltime
 EOF
 if [ "$EMAIL" != "" ]; then


### PR DESCRIPTION
Small updates for the new version to work with PBS. The ppn line needs to be in line with the nodes request such as "-l nodes=1:ppn=8". The check on RESOURCE_MANAGER to set the initial walltime was being performed before the -P flag changed RESOURCE_MANAGER.