### PR TITLE
Build: add --clean-hypre option to make_fds.sh

### DIFF
--- a/Build/Scripts/HYPRE/build_hypre.sh
+++ b/Build/Scripts/HYPRE/build_hypre.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 CONFMAKE=$1
+CLEAN_HYPRE=$2
 
 dir=`pwd`
+
+echo "CLEAN_HYPRE = $CLEAN_HYPRE"
+if [ "$CLEAN_HYPRE" = true ]; then
+  echo "Removing hypre library ..."
+  rm -r $FIREMODELS/libs/hypre
+fi
 
 echo "Checking for hypre library..."
 

--- a/Build/impi_intel_linux_db/make_fds.sh
+++ b/Build/impi_intel_linux_db/make_fds.sh
@@ -1,5 +1,63 @@
 #!/bin/bash
-ARG=$1
+
+# PARSE OPTIONS FOR CLEAN LIBRARY BUILDS ####################################
+
+# Parse the long options first using getopt
+OPTIONS=$(getopt -o "" --long clean-hypre,clean-sundials -- "$@")
+
+# Check if getopt parsed successfully
+if [ $? -ne 0 ]; then
+    echo "Error parsing options."
+    exit 1
+fi
+
+# Evaluate the parsed options
+eval set -- "$OPTIONS"
+
+# Initialize variables for options
+clean_hypre=false
+clean_sundials=false
+ARG=""
+
+# Loop through the options
+while true; do
+    case "$1" in
+        --clean-hypre)
+            clean_hypre=true  # Set the flag to true when --clean-hypre is used
+            shift
+            ;;
+        --clean-sundials)
+            clean_sundials=true
+            shift
+            ;;
+        --)
+            shift
+            break
+            ;;
+        *)
+            echo "Invalid option."
+            exit 1
+            ;;
+    esac
+done
+
+# After all options are processed, check for any remaining positional argument (ARG)
+if [ -n "$1" ]; then
+    ARG=$1
+fi
+
+# Use ARG and the options
+#echo "ARG is: $ARG"
+
+if [ "$clean_hypre" = true ]; then
+    echo "Option --clean-hypre is set."
+fi
+
+if [ "$clean_sundials" = true ]; then
+    echo "Option --clean-sundials is set."
+fi
+
+# FINISHED WITH CLEANING OPTIONS ###########################################
 
 source ../Scripts/set_intel_compiler.sh $ARG
 
@@ -7,10 +65,10 @@ dir=`pwd`
 target=${dir##*/}
 
 # build hypre
-source ../Scripts/HYPRE/build_hypre.sh confmake_impi_intel_linux.sh
+source ../Scripts/HYPRE/build_hypre.sh confmake_impi_intel_linux.sh $clean_hypre
 
 ## build sundials
-#source ../Scripts/SUNDIALS/build_sundials.sh
+#source ../Scripts/SUNDIALS/build_sundials.sh $arg-1 $arg-2 ... $clean_sundials
 
 # build fds
 echo Building $target with Intel MPI and $INTEL_IFORT


### PR DESCRIPTION
In this PR we add an optional argument to clean the hypre library on build.  So, now we have the possibilities:
1. First time build of fds + hypre from freshly cloned repos
```
cd fds/Build/impi_intel_linux_db
./make_fds.sh
```
Builds hypre and installs the library in `$FIREMODELS/libs/hypre/version`.

2. Rebuild fds with hypre library already installed.  In this case, the make script finds the hypre library and does not rebuild it.
3. Purposely clean the hypre library (remove the install) and rebuild it.
```
./make_fds.sh --clean-hypre
```
The previous hypre install will be removed and a new, clean build of the hypre library will be installed prior to fds build.
