### PR TITLE
FDS Build: set clean-fds to true for clean-hypre and clean-sundials

### DIFF
--- a/Build/Scripts/build_thirdparty_libs.sh
+++ b/Build/Scripts/build_thirdparty_libs.sh
@@ -26,10 +26,12 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --clean-hypre)
+            clean_fds=true
             clean_hypre=true  # Set the flag to true when --clean-hypre is used
             shift
             ;;
         --clean-sundials)
+            clean_fds=true
             clean_sundials=true
             shift
             ;;


### PR DESCRIPTION
@gforney, I wanted to mean that we should clean fds obj and mod files if --clean-hypre and --clean-sundials are specified. I did it for the linux part. Could you please do it for the Windows one.