### PR TITLE
FDS Build: Allow DCMAKE_MAKE_PROGRAM in cmake

### DIFF
--- a/Build/Scripts/HYPRE/build_hypre.bat
+++ b/Build/Scripts/HYPRE/build_hypre.bat
@@ -141,7 +141,9 @@ if not defined CMAKE_MAKE_PROGRAM (
     exit /b 1
 )
 
+echo.
 echo make proram is %CMAKE_MAKE_PROGRAM%
+echo.
 
 set BUILDDIR=%LIB_REPO%\src\cmbuild
 cd %BUILDDIR%

--- a/Build/Scripts/HYPRE/build_hypre.bat
+++ b/Build/Scripts/HYPRE/build_hypre.bat
@@ -137,10 +137,6 @@ if not defined CMAKE_MAKE_PROGRAM (
     for /f "delims=" %%i in ('where make.exe 2^>nul') do set CMAKE_MAKE_PROGRAM=%%i
 )
 if not defined CMAKE_MAKE_PROGRAM (
-    for /f "delims=" %%i in ('where mingw32-make.exe 2^>nul') do set CMAKE_MAKE_PROGRAM=%%i
-)
-
-if not defined CMAKE_MAKE_PROGRAM (
     echo Error: Neither make.bat nor make.exe found in PATH.
     exit /b 1
 )

--- a/Build/Scripts/HYPRE/build_hypre.bat
+++ b/Build/Scripts/HYPRE/build_hypre.bat
@@ -130,6 +130,23 @@ echo ----------------------------------------------------------
 echo ----------------------------------------------------------
 echo.
 
+::Check if make.bat or make.exe exists, and set CMAKE_MAKE_PROGRAM accordingly
+set CMAKE_MAKE_PROGRAM=
+for /f "delims=" %%i in ('where make.bat 2^>nul') do set CMAKE_MAKE_PROGRAM=%%i
+if not defined CMAKE_MAKE_PROGRAM (
+    for /f "delims=" %%i in ('where make.exe 2^>nul') do set CMAKE_MAKE_PROGRAM=%%i
+)
+if not defined CMAKE_MAKE_PROGRAM (
+    for /f "delims=" %%i in ('where mingw32-make.exe 2^>nul') do set CMAKE_MAKE_PROGRAM=%%i
+)
+
+if not defined CMAKE_MAKE_PROGRAM (
+    echo Error: Neither make.bat nor make.exe found in PATH.
+    exit /b 1
+)
+
+echo make proram is %CMAKE_MAKE_PROGRAM%
+
 set BUILDDIR=%LIB_REPO%\src\cmbuild
 cd %BUILDDIR%
 cmake ..\  ^
@@ -138,6 +155,7 @@ cmake ..\  ^
 -DCMAKE_C_COMPILER=icx ^
 -DCMAKE_C_FLAGS="/DWIN32 -O3 /fp:precise" ^
 -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded" ^
+-DCMAKE_MAKE_PROGRAM="%CMAKE_MAKE_PROGRAM%" ^
 -DCMAKE_INSTALL_LIBDIR="lib"
 
 echo.

--- a/Build/Scripts/SUNDIALS/build_sundials.bat
+++ b/Build/Scripts/SUNDIALS/build_sundials.bat
@@ -117,10 +117,6 @@ if not defined CMAKE_MAKE_PROGRAM (
     for /f "delims=" %%i in ('where make.exe 2^>nul') do set CMAKE_MAKE_PROGRAM=%%i
 )
 if not defined CMAKE_MAKE_PROGRAM (
-    for /f "delims=" %%i in ('where mingw32-make.exe 2^>nul') do set CMAKE_MAKE_PROGRAM=%%i
-)
-
-if not defined CMAKE_MAKE_PROGRAM (
     echo Error: Neither make.bat nor make.exe found in PATH.
     exit /b 1
 )

--- a/Build/Scripts/SUNDIALS/build_sundials.bat
+++ b/Build/Scripts/SUNDIALS/build_sundials.bat
@@ -110,6 +110,24 @@ echo ----------------------------------------------------------
 echo ----------------------------------------------------------
 echo.
 
+::Check if make.bat or make.exe exists, and set CMAKE_MAKE_PROGRAM accordingly
+set CMAKE_MAKE_PROGRAM=
+for /f "delims=" %%i in ('where make.bat 2^>nul') do set CMAKE_MAKE_PROGRAM=%%i
+if not defined CMAKE_MAKE_PROGRAM (
+    for /f "delims=" %%i in ('where make.exe 2^>nul') do set CMAKE_MAKE_PROGRAM=%%i
+)
+if not defined CMAKE_MAKE_PROGRAM (
+    for /f "delims=" %%i in ('where mingw32-make.exe 2^>nul') do set CMAKE_MAKE_PROGRAM=%%i
+)
+
+if not defined CMAKE_MAKE_PROGRAM (
+    echo Error: Neither make.bat nor make.exe found in PATH.
+    exit /b 1
+)
+
+echo make proram is %CMAKE_MAKE_PROGRAM%
+
+
 cmake ..\  ^
 -G "MinGW Makefiles" ^
 -DCMAKE_INSTALL_PREFIX="%INSTALLDIR%" ^
@@ -123,6 +141,7 @@ cmake ..\  ^
 -DENABLE_OPENMP=ON ^
 -DBUILD_SHARED_LIBS=OFF ^
 -DCMAKE_INSTALL_LIBDIR="lib" ^
+-DCMAKE_MAKE_PROGRAM="%CMAKE_MAKE_PROGRAM%" ^
 -DCMAKE_C_FLAGS_RELEASE="${CMAKE_C_FLAGS_RELEASE} /MT" ^
 -DCMAKE_C_FLAGS_DEBUG="${CMAKE_C_FLAGS_DEBUG} /MTd"
 

--- a/Build/Scripts/SUNDIALS/build_sundials.bat
+++ b/Build/Scripts/SUNDIALS/build_sundials.bat
@@ -121,8 +121,9 @@ if not defined CMAKE_MAKE_PROGRAM (
     exit /b 1
 )
 
+echo.
 echo make proram is %CMAKE_MAKE_PROGRAM%
-
+echo.
 
 cmake ..\  ^
 -G "MinGW Makefiles" ^


### PR DESCRIPTION
In some systems cmake  requires to explicitly state CMAKE_MAKE_PROGRAM for "MinGW Makefiles" generator. Hence, adding this option. 