### PR TITLE
FDS Build: Remove mpiifort from intel thirdparty builds

### DIFF
--- a/Build/Scripts/set_thirdparty_compilers.sh
+++ b/Build/Scripts/set_thirdparty_compilers.sh
@@ -59,7 +59,7 @@ if [[ "$FDS_BUILD_TARGET" == *"osx"* ]]; then
 elif [[ "$FDS_BUILD_TARGET" == *"intel"* ]]; then
     select_compiler CC mpiicx icx mpiicc icc
     select_compiler CXX mpiicpx icpx mpiicpc icpc
-    select_compiler FC mpiifort ifort mpiifx ifx
+    select_compiler FC ifort mpiifx ifx
 else  # Default to GNU compilers
     select_compiler CC mpicc gcc
     select_compiler CXX mpicxx g++


### PR DESCRIPTION
The latest OneAPI doesn't have ifort, but kept the mpiifort which by default search for ifort compiler. That will cause a Sundials build failure. Hence removing the mpiifort option. 