### PR TITLE
FDS Build: Test GitHub actions memory for linux.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -39,12 +39,20 @@ jobs:
           mkl
 
     - uses: actions/checkout@v4
+
+    - name: Check Current Memory Limit
+      run: ulimit -a  # Check the memory limits
+
     - name: build fds debug
       run: |
         source /opt/intel/oneapi/setvars.sh
         cd ./Build/impi_intel_linux_db
         ./make_fds.sh
         ./fds_impi_intel_linux_db
+
+    - name: Check Current Memory Limit
+      run: ulimit -a  # Check the memory limits
+
     - name: build fds release
       run: |
         source /opt/intel/oneapi/setvars.sh


### PR DESCRIPTION
Marcos and I found that during the linking phase, the intel release solver may require 1.5–2 GB of heap memory. I am adding an additional command, ulimit -a, which will print out the available memory on Ubuntu systems before starting the Debug and Release builds. This might help to identify whether the infrequent 'malloc' errors during the release build has anything to do with the system memory.