### PR TITLE
cmake: minor updates

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -271,7 +271,7 @@ jobs:
     - name: build fds
       run: |
         call Build\Scripts\setup_intel_compilers.bat
-        cmake -B builddir -S . -G Ninja -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DUSE_SUNDIALS=OFF -DUSE_HYPRE=ON -DHYPRE_FMANGLE=4 -DUSE_OPENMP=${{matrix.openmp}}
+        cmake -B builddir -S . -G Ninja -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DUSE_SUNDIALS=OFF -DUSE_HYPRE=ON -DUSE_OPENMP=${{matrix.openmp}}
         cmake --build builddir -j --target fds
 
     - name: Test

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
   cmake-linux:
     name: ${{ matrix.container }} ${{ matrix.compiler_mpi }} openmp=${{ matrix.openmp }} ${{ matrix.build_type }}
-    runs-on: [ubuntu-latest]
+    runs-on: [ubuntu-24.04]
     container: ${{ matrix.container }}
     strategy:
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,8 @@ Validation/*/FDS_Output_Files/*.csv
 
 # Verification script generated fds files
 Verification/Timing_Benchmarks/t*.fds
+
+# Local cmake configuration
+CMakeUserPresets.json
+Build/cmakeb/
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,16 +151,17 @@ if(USE_HYPRE)
         set(HYPRE_GIT_VERSION "2.32.0" )
         FetchContent_Declare(
             HYPRE
-            # GIT_REPOSITORY https://github.com/hypre-space/hypre.git
-            # GIT_TAG        b6d8c3085af64988f8f8bc21b7aef12ab49c5430 # v${HYPRE_GIT_VERSION}
-
+            GIT_REPOSITORY https://github.com/hypre-space/hypre.git
             # Currently we need to refer directly to a commit which contains a
             # patch to handle HYPRE_FMANGLE
-            GIT_REPOSITORY https://github.com/JakeOShannessy/hypre.git
-            GIT_TAG        b6d8c3085af64988f8f8bc21b7aef12ab49c5430 # v2.32.0
+            GIT_TAG        6d01417697aa84d118eb1e1eb91315df42575be5 # v${HYPRE_GIT_VERSION}
             SOURCE_SUBDIR  src
             OVERRIDE_FIND_PACKAGE
         )
+        # Set some options for building hypre
+        if (WIN32)
+            set(HYPRE_ENABLE_FMANGLE CAPS)
+        endif()
         FetchContent_MakeAvailable(HYPRE)
     endif()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,422 @@
+{
+    "version": 9,
+    "configurePresets": [
+        {
+            "name": "impi_intel",
+            "hidden": true,
+            "environment": {
+                "CC": "mpiicx",
+                "CXX": "mpiicx",
+                "FC": "mpiifx"
+            }
+        },
+        {
+            "name": "ompi_gnu",
+            "hidden": true,
+            "environment": {
+                "CC": "mpicc",
+                "CXX": "mpic++",
+                "FC": "mpifort"
+            }
+        },
+        {
+            "name": "impi_intel_rel",
+            "binaryDir": "./Build/cmakeb/impi_intel_rel",
+            "inherits": "impi_intel",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            },
+            "condition": {
+                "type": "notEquals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "impi_intel_db",
+            "binaryDir": "./Build/cmakeb/impi_intel_db",
+            "inherits": "impi_intel",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "impi_intel_dv",
+            "binaryDir": "./Build/cmakeb/impi_intel_dv",
+            "inherits": "impi_intel",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "impi_intel_win_rel",
+            "binaryDir": "./Build/cmakeb/impi_intel_win_rel",
+            "generator": "NMake Makefiles",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "impi_intel_win_db",
+            "binaryDir": "./Build/cmakeb/impi_intel_win_db",
+            "generator": "NMake Makefiles",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "impi_intel_win_dv",
+            "binaryDir": "./Build/cmakeb/impi_intel_win_dv",
+            "generator": "NMake Makefiles",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "ompi_gnu_rel",
+            "binaryDir": "./Build/cmakeb/ompi_gnu_rel",
+            "inherits": "ompi_gnu",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "ompi_gnu_db",
+            "binaryDir": "./Build/cmakeb/ompi_gnu_db",
+            "inherits": "ompi_gnu",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "ompi_gnu_dv",
+            "binaryDir": "./Build/cmakeb/ompi_gnu_dv",
+            "inherits": "ompi_gnu",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "impi_intel_rel",
+            "configurePreset": "impi_intel_rel",
+            "jobs": 0,
+            "condition": {
+                "type": "notEquals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "impi_intel_db",
+            "configurePreset": "impi_intel_db",
+            "jobs": 0
+        },
+        {
+            "name": "impi_intel_dv",
+            "configurePreset": "impi_intel_dv",
+            "jobs": 0
+        },
+        {
+            "name": "impi_intel_win_rel",
+            "configurePreset": "impi_intel_win_rel",
+            "jobs": 0,
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "impi_intel_win_db",
+            "configurePreset": "impi_intel_win_db",
+            "jobs": 0,
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "impi_intel_win_dv",
+            "configurePreset": "impi_intel_win_dv",
+            "jobs": 0,
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "ompi_gnu_rel",
+            "configurePreset": "ompi_gnu_rel",
+            "jobs": 0
+        },
+        {
+            "name": "ompi_gnu_db",
+            "configurePreset": "ompi_gnu_db",
+            "jobs": 0
+        },
+        {
+            "name": "ompi_gnu_dv",
+            "configurePreset": "ompi_gnu_dv",
+            "jobs": 0
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "impi_intel_rel",
+            "configurePreset": "impi_intel_rel",
+            "execution": {
+                "jobs": 0
+            },
+            "condition": {
+                "type": "notEquals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "impi_intel_db",
+            "configurePreset": "impi_intel_db",
+            "execution": {
+                "jobs": 0
+            }
+        },
+        {
+            "name": "impi_intel_dv",
+            "configurePreset": "impi_intel_dv",
+            "execution": {
+                "jobs": 0
+            }
+        },
+        {
+            "name": "impi_intel_win_rel",
+            "configurePreset": "impi_intel_win_rel",
+            "execution": {
+                "jobs": 0
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "impi_intel_win_db",
+            "configurePreset": "impi_intel_win_db",
+            "execution": {
+                "jobs": 0
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "impi_intel_win_dv",
+            "configurePreset": "impi_intel_win_dv",
+            "execution": {
+                "jobs": 0
+            },
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "name": "ompi_gnu_rel",
+            "configurePreset": "ompi_gnu_rel",
+            "execution": {
+                "jobs": 0
+            }
+        },
+        {
+            "name": "ompi_gnu_db",
+            "configurePreset": "ompi_gnu_db",
+            "execution": {
+                "jobs": 0
+            }
+        },
+        {
+            "name": "ompi_gnu_dv",
+            "configurePreset": "ompi_gnu_dv",
+            "execution": {
+                "jobs": 0
+            }
+        }
+    ],
+    "workflowPresets": [
+        {
+            "name": "impi_intel_rel",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "impi_intel_rel"
+                },
+                {
+                    "type": "build",
+                    "name": "impi_intel_rel"
+                },
+                {
+                    "type": "test",
+                    "name": "impi_intel_rel"
+                }
+            ]
+        },
+        {
+            "name": "impi_intel_db",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "impi_intel_db"
+                },
+                {
+                    "type": "build",
+                    "name": "impi_intel_db"
+                },
+                {
+                    "type": "test",
+                    "name": "impi_intel_db"
+                }
+            ]
+        },
+        {
+            "name": "impi_intel_dv",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "impi_intel_dv"
+                },
+                {
+                    "type": "build",
+                    "name": "impi_intel_dv"
+                },
+                {
+                    "type": "test",
+                    "name": "impi_intel_dv"
+                }
+            ]
+        },
+        {
+            "name": "impi_intel_win_rel",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "impi_intel_win_rel"
+                },
+                {
+                    "type": "build",
+                    "name": "impi_intel_win_rel"
+                },
+                {
+                    "type": "test",
+                    "name": "impi_intel_win_rel"
+                }
+            ]
+        },
+        {
+            "name": "impi_intel_win_db",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "impi_intel_win_db"
+                },
+                {
+                    "type": "build",
+                    "name": "impi_intel_win_db"
+                },
+                {
+                    "type": "test",
+                    "name": "impi_intel_win_db"
+                }
+            ]
+        },
+        {
+            "name": "impi_intel_win_dv",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "impi_intel_win_dv"
+                },
+                {
+                    "type": "build",
+                    "name": "impi_intel_win_dv"
+                },
+                {
+                    "type": "test",
+                    "name": "impi_intel_win_dv"
+                }
+            ]
+        },
+        {
+            "name": "ompi_gnu_rel",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "ompi_gnu_rel"
+                },
+                {
+                    "type": "build",
+                    "name": "ompi_gnu_rel"
+                },
+                {
+                    "type": "test",
+                    "name": "ompi_gnu_rel"
+                }
+            ]
+        },
+        {
+            "name": "ompi_gnu_db",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "ompi_gnu_db"
+                },
+                {
+                    "type": "build",
+                    "name": "ompi_gnu_db"
+                },
+                {
+                    "type": "test",
+                    "name": "ompi_gnu_db"
+                }
+            ]
+        },
+        {
+            "name": "ompi_gnu_dv",
+            "steps": [
+                {
+                    "type": "configure",
+                    "name": "ompi_gnu_dv"
+                },
+                {
+                    "type": "build",
+                    "name": "ompi_gnu_dv"
+                },
+                {
+                    "type": "test",
+                    "name": "ompi_gnu_dv"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This PR makes a few changes:
  - The upstream hypre patch has been accepted. Now we point to a new revision of hypre that includes the patch to HYPRE_FMANGLE. This also forces the use of HYPRE_FMANGLE on windows.
  - Replace ubuntu-latest with ubuntu-24.04 to pre-empt this future change.
  - Add a CMakePresets.json file which include some example build workflows
that might be useful.

I haven't added all of the build types in Build/ as most of these can be easily created by setting options (e.g. ENABLE_OPENMP=ON) but they might serve as useful examples. The can be listed in the following way:

```sh
cmake --workflow --list-presets
```
which shows:
```sh
Available workflow presets:

  "impi_intel_rel"
  "impi_intel_db"
  "impi_intel_dv"
  "impi_intel_win_rel"
  "impi_intel_win_db"
  "impi_intel_win_dv"
  "ompi_gnu_rel"
  "ompi_gnu_db"
  "ompi_gnu_dv"
```

and executed using:

```sh
cmake --workflow --preset impi_intel_win_db
```
