### PR TITLE
FDS Source: use Z_LS to build terrain files for both OBST and GEOM cases

### DIFF
--- a/Source/dump.f90
+++ b/Source/dump.f90
@@ -988,11 +988,7 @@ IF (TERRAIN_CASE) THEN
    ALLOCATE(OUT_OF_MESH(0:M%IBAR,0:M%JBAR)) ; OUT_OF_MESH = .FALSE.
    DO J=0,M%JBAR
       DO I=0,M%IBAR
-         IF (CC_IBM) THEN
-            Z_TERRAIN(I,J) = REAL(M%GEOM_ZMAX(I,J),FB)
-         ELSE
-            Z_TERRAIN(I,J) = REAL(0.25_EB*(M%Z_LS(I,J)+M%Z_LS(I+1,J)+M%Z_LS(I,J+1)+M%Z_LS(I+1,J+1)),FB)
-         ENDIF
+         Z_TERRAIN(I,J) = REAL(0.25_EB*(M%Z_LS(I,J)+M%Z_LS(I+1,J)+M%Z_LS(I,J+1)+M%Z_LS(I+1,J+1)),FB)
          IF (Z_TERRAIN(I,J)<M%ZS .OR. Z_TERRAIN(I,J)>M%ZF) OUT_OF_MESH(I,J) = .TRUE.
       ENDDO
    ENDDO


### PR DESCRIPTION
@marcosvanella I will let you determine the best way to clean up the use of `GEOM_ZMAX`