### PR TITLE
KuljeetMaan: kappa for band is now based on kappa_effective

### DIFF
--- a/Source/radi.f90
+++ b/Source/radi.f90
@@ -3294,7 +3294,7 @@ MAKE_KAPPA_ARRAYS: IF (.NOT.SOLID_PHASE_ONLY .AND. ANY(SPECIES%RADCAL_ID/='null'
                   IF (NSB==1 .AND. PATH_LENGTH > 0.0_EB) THEN
                      RADCAL_SPECIES2KAPPA(NS,J,K,1) = MIN(AMEAN,AP0)
                   ELSE
-                     RADCAL_SPECIES2KAPPA(NS,J,K,IBND) = AP0/BBF
+                     RADCAL_SPECIES2KAPPA(NS,J,K,IBND) = AMEAN/BBF
                   ENDIF
                END DO RADCAL_SPECIES_LOOP
             ENDDO Y_LOOP_Z


### PR DESCRIPTION
The absorption coefficient in each band is modified to be calculated using  K_effective (RADCAL) instead of being based on Planck mean values.