### PR TITLE
FDS Actions: Allow ifx debug compilation only

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,8 +24,6 @@ permissions:
 
 jobs:
   linux-intel-intelmpi:
-    if: false # skip this run until ifx issue is sorted out
-
     # build on ubuntu using ifort with intelmpi and mkl based on
     # https://github.com/oneapi-src/oneapi-ci
 
@@ -59,6 +57,7 @@ jobs:
       run: free -h  
 
     - name: build fds release
+      if: false # skip this run until ifx issue is sorted out
       run: |
         source /opt/intel/oneapi/setvars.sh
         cd ./Build/impi_intel_linux

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -80,7 +80,6 @@ jobs:
         echo $GITHUB_WORKSPACE
         cd $GITHUB_WORKSPACE/Utilities/Python
         python hello_world.py
-        python FDS_verification_script.py
 
   linux-gnu-openmpi:
     # build on ubuntu using gfortran with openmpi and mkl based on


### PR DESCRIPTION
The ifx debug compilation does not fail with the -ipo option; only the release version have issues. Therefore, enabling ifx debug compilation in GitHub Actions.