### PR TITLE
gh-actions: add intel 2025.2.0 release packages.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,9 +2,9 @@ name: cmake
 env:
   # update urls for oneapi packages according to
   # https://github.com/oneapi-src/oneapi-ci/blob/master/.github/workflows/build_all.yml
-  WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ae29263e-38b9-4d43-86c3-376d6e0668e7/intel-oneapi-base-toolkit-2025.0.1.47_offline.exe
+  WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/09a8acaf-265f-4460-866c-a3375ed5b4ff/intel-oneapi-base-toolkit-2025.2.0.591_offline.exe
   WINDOWS_BASEKIT_COMPONENTS: intel.oneapi.win.mkl.devel
-  WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/a37c30c3-a846-4371-a85d-603e9a9eb94c/intel-oneapi-hpc-toolkit-2025.0.1.48_offline.exe
+  WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/3bbdaf75-6728-492e-a18c-be654dae9ee2/intel-oneapi-hpc-toolkit-2025.2.0.576_offline.exe
   WINDOWS_HPCKIT_COMPONENTS: intel.oneapi.win.ifort-compiler:intel.oneapi.win.mpi.devel
 
 on:
@@ -79,10 +79,10 @@ jobs:
       # if: endsWith(matrix.compiler_mpi, '_intelmpi')
       with:
         components: |
-          ifx@2025.0.1
-          icx@2025.0.1
-          impi@2021.14.1
-          mkl@2025.0.1
+          ifx
+          icx
+          impi
+          mkl
 
     - name: install openmpi
       if: endsWith(matrix.compiler_mpi, '_openmpi') && (startsWith(matrix.container, 'rockylinux') || startsWith(matrix.container, 'fedora'))

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,9 +34,9 @@ jobs:
     - uses: rscohn2/setup-oneapi@v0
       with:
         components: |
-          ifx@2025.0.1
-          impi@2021.14.1
-          mkl@2025.0.1
+          ifx
+          impi
+          mkl
         prune: false       
          
     - uses: actions/checkout@v4

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -41,12 +41,6 @@ jobs:
          
     - uses: actions/checkout@v4
 
-    - name: Check Current Memory Limit
-      run: ulimit -a  # Check the memory limits
-
-    - name: free -h command
-      run: free -h  
-
     - name: build fds debug
       run: |
         source /opt/intel/oneapi/setvars.sh
@@ -54,19 +48,12 @@ jobs:
         ./make_fds.sh
         ./fds_impi_intel_linux_db
 
-    - name: free -h command
-      run: free -h  
-
     - name: build fds release
-      if: false # skip this run until ifx issue is sorted out
       run: |
         source /opt/intel/oneapi/setvars.sh
         cd ./Build/impi_intel_linux
         ./make_fds.sh
         ./fds_impi_intel_linux
-
-    - name: free -h command
-      run: free -h  
 
     # Setup python
     - uses: actions/setup-python@v5

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -97,7 +97,7 @@ jobs:
     - uses: rscohn2/setup-oneapi@v0
       with:
         components: |
-          mkl
+          mkl@2025.1.0
         prune: false  
 
     - uses: actions/checkout@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,9 +26,9 @@ permissions:
 env:
   # update urls for oneapi packages according to
   # https://github.com/oneapi-src/oneapi-ci/blob/master/.github/workflows/build_all.yml
-  WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ae29263e-38b9-4d43-86c3-376d6e0668e7/intel-oneapi-base-toolkit-2025.0.1.47_offline.exe
+  WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/09a8acaf-265f-4460-866c-a3375ed5b4ff/intel-oneapi-base-toolkit-2025.2.0.591_offline.exe
   WINDOWS_BASEKIT_COMPONENTS: intel.oneapi.win.mkl.devel
-  WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/a37c30c3-a846-4371-a85d-603e9a9eb94c/intel-oneapi-hpc-toolkit-2025.0.1.48_offline.exe
+  WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/3bbdaf75-6728-492e-a18c-be654dae9ee2/intel-oneapi-hpc-toolkit-2025.2.0.576_offline.exe
   WINDOWS_HPCKIT_COMPONENTS: intel.oneapi.win.ifort-compiler:intel.oneapi.win.mpi.devel
 
 


### PR DESCRIPTION
There used to be incompatibilities between the `ifx` and `mkl` packages as observed first in #13994. It appears that they have been fixed.

Let's see if the testers agree!