### PR TITLE
FDS User Guide: MEAN_DIAMETER added for example of Aerosol Deposition

### DIFF
--- a/Manuals/FDS_User_Guide/FDS_User_Guide.tex
+++ b/Manuals/FDS_User_Guide/FDS_User_Guide.tex
@@ -5679,7 +5679,7 @@ Note that the stoichiometric coefficient for soot ensures that the mass of soot 
 &SPEC ID = 'NITROGEN',          LUMPED_COMPONENT_ONLY = T /
 &SPEC ID = 'WATER VAPOR',       LUMPED_COMPONENT_ONLY = T /
 &SPEC ID = 'CARBON DIOXIDE',    LUMPED_COMPONENT_ONLY = T /
-&SPEC ID = 'SOOT',              AEROSOL = T /
+&SPEC ID = 'SOOT',              AEROSOL = T, MEAN_DIAMETER=1.E-6 /
 \end{lstlisting}
 If Eq.~(\ref{eq:PROPANE_depo}) is properly balanced, you can directly use the stoichiometric coefficients of the primitive species to define the lumped species:
 


### PR DESCRIPTION
Add MEAN_DIAMETER to SPEC ID="SOOT" for example of Aerosol Deposition based on Verification case [propane_flame_deposition.fds](https://github.com/firemodels/fds/blob/13faa48a9ea4674344fcfd37f54c2eb7421fcb0d/Verification/Aerosols/propane_flame_deposition.fds#L28C35-L28C54)
Line 28: `&SPEC ID = 'SOOT', AEROSOL=.TRUE.,MEAN_DIAMETER=1.E-6 /`