### PR TITLE
github-actions: macos changes

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -109,9 +109,9 @@ jobs:
       if: startsWith(matrix.compiler_mpi, 'intel_')
       shell: bash
       run: |
-        echo "CC=mpiicx" >> $GITHUB_ENV
-        echo "CXX=mpiicx" >> $GITHUB_ENV
-        echo "FC=mpiifx" >> $GITHUB_ENV
+        echo "CC=icx" >> $GITHUB_ENV
+        echo "CXX=icpx" >> $GITHUB_ENV
+        echo "FC=ifx" >> $GITHUB_ENV
 
     - name: build fds
       if: endsWith(matrix.compiler_mpi, '_intelmpi')
@@ -148,7 +148,6 @@ jobs:
         ctest --test-dir builddir -j --output-on-failure -V
 
   cmake-osx:
-    if: false
     # Set the name of this build, variable depending on the OS
     name: ${{ matrix.os }} ${{ matrix.compiler_mpi }} openmp=${{ matrix.openmp }} ${{ matrix.build_type }}
     strategy:
@@ -157,7 +156,7 @@ jobs:
       # and build configurations
       matrix:
         os:
-          - macos-latest
+          - macos-14
         compiler_mpi:
           - "gnu_openmpi"
         openmp:
@@ -172,7 +171,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: install openmpi
-        run: brew install open-mpi
+        run: brew install gcc@15 open-mpi
 
       - name: set macos gcc
         if: startsWith(matrix.compiler_mpi, 'gnu_')
@@ -181,6 +180,8 @@ jobs:
           echo "CC=gcc-15" >> $GITHUB_ENV
           echo "CXX=g++-15" >> $GITHUB_ENV
           echo "FC=gfortran-15" >> $GITHUB_ENV
+          echo "OMPI_CC=gcc-15" >> $GITHUB_ENV
+          echo "OMPI_CXX=g++-15" >> $GITHUB_ENV
           echo "OMPI_FC=gfortran-15" >> $GITHUB_ENV
           brew install glew gd zlib json-c
 
@@ -189,9 +190,11 @@ jobs:
         shell: bash
         run: |
           echo "CC=icx" >> $GITHUB_ENV
-          echo "CXX=icx" >> $GITHUB_ENV
-          echo "FC=mpiifx" >> $GITHUB_ENV
-          echo "OMPI_FC=mpiifx" >> $GITHUB_ENV
+          echo "CXX=icpx" >> $GITHUB_ENV
+          echo "FC=ifx" >> $GITHUB_ENV
+          echo "OMPI_CC=icx" >> $GITHUB_ENV
+          echo "OMPI_CXX=icpx" >> $GITHUB_ENV
+          echo "OMPI_FC=ifx" >> $GITHUB_ENV
 
       - name: Build
         if: startsWith(matrix.compiler_mpi, 'gnu_')
@@ -221,7 +224,7 @@ jobs:
   cmake-windows:
     # build on windows using ifort with intelmpi and mkl based on
     # https://github.com/oneapi-src/oneapi-ci
-    if: false
+
     name: windows ${{matrix.compiler}} intelmpi openmp=${{ matrix.openmp }} ${{ matrix.build_type }}
     runs-on: [windows-latest]
     strategy:

--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -28,7 +28,7 @@ jobs:
     # debug build on osx using gfortran with openmpi
   
     name: osx gnu openmpi
-    runs-on: [macos-latest]
+    runs-on: [macos-14]
     defaults:
       run:
         shell: bash
@@ -37,7 +37,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: install openmpi
       run: |
-        brew install open-mpi
+        brew install gcc@15 open-mpi
         echo "OMPI_FC=gfortran-15" >> $GITHUB_ENV
 
     - name: build fds debug


### PR DESCRIPTION
Fixes #14963.

Specify the correct compilers. Explicitly install gcc 15. Only run on macos-14 image for the moment.