### PR TITLE
FDS Source: Fix error for PROF and PART with INIT and multiple MESH

### DIFF
--- a/Source/init.f90
+++ b/Source/init.f90
@@ -2699,7 +2699,7 @@ PROF_LOOP: DO N=1,N_PROF
 
    ! Check for potential errors
 
-   IF (SF%THERMAL_BC_INDEX/=THERMALLY_THICK) THEN
+   IF (SF%THERMAL_BC_INDEX/=THERMALLY_THICK .AND. (PF%IOR/=0 .OR. (PF%IOR==0 .AND. PF%MESH==NM))) THEN
       WRITE(LU_ERR,'(A,I0,A)') 'ERROR(430): PROF ',N,' must be associated with a heat-conducting surface.'
       STOP_STATUS = SETUP_STOP
       RETURN


### PR DESCRIPTION
Had a case where I put one particle each in two MESHes with INIT and had a bunch of PROF outputs for each particle. The case failed with error 430 when it got to processing the first PROF for the second MESH. The cause was it was trying to process the surface type for the profile for a particle on the second mesh while still on the first mesh. I made a single line edit to the logic for the error message. Now it only checks for the type of surface if it is not a particle or if it is a particle and in the mesh where the particle is. Can you take a look at the edit? I feel like I am probably missing something.