### PR TITLE
this PR prevents errors or warning from biber from being lost by puttting them into a file that is not overwritten

### DIFF
--- a/Manuals/FDS_Config_Management_Plan/make_guide.sh
+++ b/Manuals/FDS_Config_Management_Plan/make_guide.sh
@@ -11,10 +11,11 @@ gitrevision=`git describe --abbrev=7 --long --dirty`
 echo "\\newcommand{\\gitrevision}{$gitrevision}" > ../Bibliography/gitrevision.tex
 
 pdflatex -interaction nonstopmode FDS_Config_Management_Plan &> FDS_Config_Management_Plan.err
-biber FDS_Config_Management_Plan &> FDS_Config_Management_Plan.err
+biber                             FDS_Config_Management_Plan &> FDS_Config_Management_Plan_biber.err
 pdflatex -interaction nonstopmode FDS_Config_Management_Plan &> FDS_Config_Management_Plan.err
 pdflatex -interaction nonstopmode FDS_Config_Management_Plan &> FDS_Config_Management_Plan.err
 pdflatex -interaction nonstopmode FDS_Config_Management_Plan &> FDS_Config_Management_Plan.err
+cat FDS_Config_Management_Plan_biber.err >> FDS_Config_Management_Plan.err
 
 # make sure the guide exists
 if [ ! -e FDS_Config_Management_Plan.pdf ]; then
@@ -34,13 +35,13 @@ if [[ `grep -E "Too many|Undefined control sequence|Error:|Fatal error|! LaTeX E
 fi
 
 # Check for LaTeX warnings (undefined references or duplicate labels)
-if [[ `grep -E "undefined|multiply defined|multiply-defined" -I FDS_Config_Management_Plan.err` == "" ]]
+if [[ `grep -E "undefined|WARNING|ERROR|multiply defined|multiply-defined" -I FDS_Config_Management_Plan.err` == "" ]]
    then
       # Continue along
       :
    else
       echo "LaTeX warnings detected:"
-      grep -E "undefined|multiply defined|multiply-defined" -I FDS_Config_Management_Plan.err
+      grep -E "undefined|WARNING|ERROR|multiply defined|multiply-defined" -I FDS_Config_Management_Plan.err
       clean_build=0
 fi
 

--- a/Manuals/FDS_Technical_Reference_Guide/make_guide.sh
+++ b/Manuals/FDS_Technical_Reference_Guide/make_guide.sh
@@ -11,10 +11,11 @@ gitrevision=`git describe --abbrev=7 --long --dirty`
 echo "\\newcommand{\\gitrevision}{$gitrevision}" > ../Bibliography/gitrevision.tex
 
 pdflatex -interaction nonstopmode FDS_Technical_Reference_Guide &> FDS_Technical_Reference_Guide.err
-biber FDS_Technical_Reference_Guide &> FDS_Technical_Reference_Guide.err
+biber                             FDS_Technical_Reference_Guide &> FDS_Technical_Reference_Guide_biber.err
 pdflatex -interaction nonstopmode FDS_Technical_Reference_Guide &> FDS_Technical_Reference_Guide.err
 pdflatex -interaction nonstopmode FDS_Technical_Reference_Guide &> FDS_Technical_Reference_Guide.err
 pdflatex -interaction nonstopmode FDS_Technical_Reference_Guide &> FDS_Technical_Reference_Guide.err
+cat FDS_Technical_Reference_Guide_biber.err >> FDS_Technical_Reference_Guide.err
 
 # make sure the guide exists
 if [ ! -e FDS_Technical_Reference_Guide.pdf ]; then
@@ -34,13 +35,13 @@ if [[ `grep -E "Too many|Undefined control sequence|Error:|Fatal error|! LaTeX E
 fi
 
 # Check for LaTeX warnings (undefined references or duplicate labels)
-if [[ `grep -E "undefined|multiply defined|multiply-defined" -I FDS_Technical_Reference_Guide.err` == "" ]]
+if [[ `grep -E "undefined|WARNING|ERROR|multiply defined|multiply-defined" -I FDS_Technical_Reference_Guide.err` == "" ]]
    then
       # Continue along
       :
    else
       echo "LaTeX warnings detected:"
-      grep -E "new file|undefined|multiply defined|multiply-defined" -I FDS_Technical_Reference_Guide.err
+      grep -E "new file|undefined|WARNING|ERROR|multiply defined|multiply-defined" -I FDS_Technical_Reference_Guide.err
       clean_build=0
 fi
 

--- a/Manuals/FDS_User_Guide/make_guide.sh
+++ b/Manuals/FDS_User_Guide/make_guide.sh
@@ -11,10 +11,11 @@ gitrevision=`git describe --abbrev=7 --long --dirty`
 echo "\\newcommand{\\gitrevision}{$gitrevision}" > ../Bibliography/gitrevision.tex
 
 pdflatex -interaction nonstopmode FDS_User_Guide &> FDS_User_Guide.err
-biber FDS_User_Guide &> FDS_User_Guide.err
+biber                             FDS_User_Guide &> FDS_User_Guide_biber.err
 pdflatex -interaction nonstopmode FDS_User_Guide &> FDS_User_Guide.err
 pdflatex -interaction nonstopmode FDS_User_Guide &> FDS_User_Guide.err
 pdflatex -interaction nonstopmode FDS_User_Guide &> FDS_User_Guide.err
+cat FDS_User_Guide_biber.err >> FDS_User_Guide.err
 
 # make sure the guide exists
 if [ ! -e FDS_User_Guide.pdf ]; then
@@ -34,13 +35,13 @@ if [[ `grep -E "Too many|Undefined control sequence|Error:|Fatal error|! LaTeX E
 fi
 
 # Check for LaTeX warnings (undefined references or duplicate labels)
-if [[ `grep -E "undefined|multiply defined|multiply-defined" -I FDS_User_Guide.err` == "" ]]
+if [[ `grep -E "undefined|WARNING|ERROR|multiply defined|multiply-defined" -I FDS_User_Guide.err` == "" ]]
    then
       # Continue along
       :
    else
       echo "LaTeX warnings detected:"
-      grep -E "undefined|multiply defined|multiply-defined" -I FDS_User_Guide.err
+      grep -E "undefined|WARNING|ERROR|multiply defined|multiply-defined" -I FDS_User_Guide.err
       clean_build=0
 fi
 

--- a/Manuals/FDS_Validation_Guide/make_guide.sh
+++ b/Manuals/FDS_Validation_Guide/make_guide.sh
@@ -20,10 +20,11 @@ gitrevision=`git describe --abbrev=7 --long --dirty`
 echo "\\newcommand{\\gitrevision}{$gitrevision}" > ../Bibliography/gitrevision.tex
 
 pdflatex -interaction nonstopmode FDS_Validation_Guide &> FDS_Validation_Guide.err
-biber FDS_Validation_Guide &> FDS_Validation_Guide.err
+biber                             FDS_Validation_Guide &> FDS_Validation_Guide_biber.err
 pdflatex -interaction nonstopmode FDS_Validation_Guide &> FDS_Validation_Guide.err
 pdflatex -interaction nonstopmode FDS_Validation_Guide &> FDS_Validation_Guide.err
 pdflatex -interaction nonstopmode FDS_Validation_Guide &> FDS_Validation_Guide.err
+cat FDS_Validation_Guide_biber.err >> FDS_Validation_Guide.err
 
 # make sure the guide exists
 if [ ! -e FDS_Validation_Guide.pdf ]; then
@@ -47,13 +48,13 @@ if [[ `grep -E "Too many|Undefined control sequence|Error:|Fatal error|! LaTeX E
 fi
 
 # Check for LaTeX warnings (undefined references or duplicate labels)
-if [[ `grep -E "undefined|multiply defined" -I FDS_Validation_Guide.err | grep -v RF1 | grep -v RF2 | grep -v LastPage` == "" ]]
+if [[ `grep -E "undefined|WARNING|ERROR|multiply defined" -I FDS_Validation_Guide.err | grep -v RF1 | grep -v RF2 | grep -v LastPage` == "" ]]
    then
       # Continue along
       :
    else
       echo "LaTeX warnings detected:"
-      grep -E "undefined|multiply defined" -I FDS_Validation_Guide.err | grep -v RF1 | grep -v RF2 | grep -v LastPage
+      grep -E "undefined|WARNING|ERROR|multiply defined" -I FDS_Validation_Guide.err | grep -v RF1 | grep -v RF2 | grep -v LastPage
       clean_build=0
 fi
 

--- a/Manuals/FDS_Verification_Guide/make_guide.sh
+++ b/Manuals/FDS_Verification_Guide/make_guide.sh
@@ -20,10 +20,11 @@ gitrevision=`git describe --abbrev=7 --long --dirty`
 echo "\\newcommand{\\gitrevision}{$gitrevision}" > ../Bibliography/gitrevision.tex
 
 pdflatex -interaction nonstopmode FDS_Verification_Guide &> FDS_Verification_Guide.err
-biber FDS_Verification_Guide &> FDS_Verification_Guide.err
+biber                             FDS_Verification_Guide &> FDS_Verification_Guide_biber.err
 pdflatex -interaction nonstopmode FDS_Verification_Guide &> FDS_Verification_Guide.err
 pdflatex -interaction nonstopmode FDS_Verification_Guide &> FDS_Verification_Guide.err
 pdflatex -interaction nonstopmode FDS_Verification_Guide &> FDS_Verification_Guide.err
+cat FDS_Verification_Guide_biber.err >> FDS_Verification_Guide.err
 
 if [ ! -e FDS_Verification_Guide.pdf ]; then
   clean_build=0
@@ -46,13 +47,13 @@ if [[ `grep -E "Too many|Undefined control sequence|Error:|Fatal error|! LaTeX E
 fi
 
 # Check for LaTeX warnings (undefined references or duplicate labels)
-if [[ `grep -E "undefined|multiply defined" -I FDS_Verification_Guide.err | grep -v RF1 | grep -v LastPage` == "" ]]
+if [[ `grep -E "undefined|WARNING|ERROR|multiply defined" -I FDS_Verification_Guide.err | grep -v RF1 | grep -v LastPage` == "" ]]
    then
       # Continue along
       :
    else
       echo "LaTeX warnings detected:"
-      grep -E "undefined|multiply defined" -I FDS_Verification_Guide.err | grep -v RF1 | grep -v LastPage
+      grep -E "undefined|WARNING|ERROR|multiply defined" -I FDS_Verification_Guide.err | grep -v RF1 | grep -v LastPage
       clean_build=0
 fi
 


### PR DESCRIPTION
in the make_guide.sh scripts, pdflatex was over-writing the output generated by biber so any errors or warnings occurring during the biber step would be lost.  this PR separates puts biber output into a separate file.  firebot in my fork did not find any errors or warnings from biber 