### PR TITLE
test_mpi build: remove a few compiler options from the ompi_gnu_osx m…

### DIFF
--- a/Utilities/test_mpi/makefile
+++ b/Utilities/test_mpi/makefile
@@ -65,8 +65,8 @@ ompi_intel_osx: obj = test_mpi
 ompi_intel_osx: $(obj_mpi)
 	$(FCOMPL) -o $(obj) $(FFLAGS) $(LFLAGS) $(obj_mpi)
 
-ompi_gnu_osx: FFLAGS = -m64 -O2 -traceback -no-wrap-margin
-ompi_gnu_osx: LFLAGS = -static-intel -ld_classic
+ompi_gnu_osx: FFLAGS = -m64 -O2
+ompi_gnu_osx: LFLAGS =
 ompi_gnu_osx: FCOMPL = mpifort
 ompi_gnu_osx: obj = test_mpi
 ompi_gnu_osx: $(obj_mpi)


### PR DESCRIPTION
…akefile entry not supported or deprecated