### PR TITLE
gh-actions: Updated oneAPI to 2026.0.0 in cmake.yml.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,10 +2,8 @@ name: cmake
 env:
   # update urls for oneapi packages according to
   # https://github.com/oneapi-src/oneapi-ci/blob/master/.github/workflows/build_all.yml
-  WINDOWS_BASEKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/09a8acaf-265f-4460-866c-a3375ed5b4ff/intel-oneapi-base-toolkit-2025.2.0.591_offline.exe
-  WINDOWS_BASEKIT_COMPONENTS: intel.oneapi.win.mkl.devel
-  WINDOWS_HPCKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/3bbdaf75-6728-492e-a18c-be654dae9ee2/intel-oneapi-hpc-toolkit-2025.2.0.576_offline.exe
-  WINDOWS_HPCKIT_COMPONENTS: intel.oneapi.win.ifort-compiler:intel.oneapi.win.mpi.devel
+  WINDOWS_TOOLKIT_URL: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/bae85ab1-cfcd-4251-8d42-a0c27949ea33/intel-oneapi-toolkit-2026.0.0.193_offline.exe
+  WINDOWS_TOOLKIT_COMPONENTS: intel.oneapi.win.ifort-compiler:intel.oneapi.win.mpi.devel:intel.oneapi.win.mkl.devel
 
 on:
   push:
@@ -254,23 +252,15 @@ jobs:
       uses: actions/cache@v5
       with:
         path: C:\Program Files (x86)\Intel\oneAPI\
-        key: install-${{ env.WINDOWS_BASEKIT_URL }}-${{ env.WINDOWS_BASEKIT_COMPONENTS }}-${{ env.WINDOWS_HPCKIT_URL }}-${{ env.WINDOWS_HPCKIT_COMPONENTS }}
-    - name: install oneapi mkl
+        key: install-${{ env.WINDOWS_TOOLKIT_URL }}-${{ env.WINDOWS_TOOLKIT_COMPONENTS }}
+    - name: install oneapi compiler, mpi, mkl
       if: steps.cache-install.outputs.cache-hit != 'true'
       run: |
-        curl.exe --output %TEMP%\webimage_base.exe --url %WINDOWS_BASEKIT_URL% --retry 5 --retry-delay 5
-        start /b /wait %TEMP%\webimage_base.exe -s -x -f webimage_base_extracted --log extract_base.log
-        del %TEMP%\webimage_base.exe
-        webimage_base_extracted\bootstrapper.exe -s --action install --components=%WINDOWS_BASEKIT_COMPONENTS% --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 --log-dir=.
-        rd /s/q "webimage_base_extracted"
-    - name: install oneapi compiler, mpi
-      if: steps.cache-install.outputs.cache-hit != 'true'
-      run: |
-        curl.exe --output %TEMP%\webimage_hpc.exe --url %WINDOWS_HPCKIT_URL% --retry 5 --retry-delay 5
-        start /b /wait %TEMP%\webimage_hpc.exe -s -x -f webimage_hpc_extracted --log extract_hpc.log
-        del %TEMP%\webimage_hpc.exe
-        webimage_hpc_extracted\bootstrapper.exe -s --action install --components=%WINDOWS_HPCKIT_COMPONENTS% --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 --log-dir=.
-        rd /s/q "webimage_hpc_extracted"
+        curl.exe --output %TEMP%\webimage.exe --url %WINDOWS_TOOLKIT_URL% --retry 5 --retry-delay 5
+        start /b /wait %TEMP%\webimage.exe -s -x -f webimage_extracted --log extract.log
+        del %TEMP%\webimage.exe
+        webimage_extracted\bootstrapper.exe -s --action install --components=%WINDOWS_TOOLKIT_COMPONENTS% --eula=accept -p=NEED_VS2017_INTEGRATION=0 -p=NEED_VS2019_INTEGRATION=0 --log-dir=.
+        rd /s/q "webimage_extracted"
 
     - name: build fds
       run: |


### PR DESCRIPTION
Should fix #16330.

@marcosvanella -- Apologies for skipping cmake.yml in #16229