### PR TITLE
test_mpi build: remove -ld_classic from osx intel build - was causing…

### DIFF
--- a/Utilities/test_mpi/makefile
+++ b/Utilities/test_mpi/makefile
@@ -66,7 +66,7 @@ ompi_gnu_linux: $(obj_mpi)
 # OSX
 
 ompi_intel_osx: FFLAGS = -m64 -O2 -traceback -no-wrap-margin
-ompi_intel_osx: LFLAGS = -static-intel -ld_classic
+ompi_intel_osx: LFLAGS = -static-intel
 ompi_intel_osx: FCOMPL = mpifort
 ompi_intel_osx: obj = test_mpi
 ompi_intel_osx: $(obj_mpi)


### PR DESCRIPTION
… build to crash