### PR TITLE
FDS Scripts: Remove unneeded option from qfds.sh

### DIFF
--- a/Utilities/Scripts/qfds.sh
+++ b/Utilities/Scripts/qfds.sh
@@ -458,7 +458,6 @@ EOF
 if [ "$use_intel_mpi" == "1" ]; then
 cat << EOF >> $scriptfile
 export I_MPI_DEBUG=5
-export I_MPI_PMI_VALUE_LENGTH_MAX=512
 EOF
 fi
 


### PR DESCRIPTION
I added this option when we were having I/O problems with the new compute cluster. This option probably had no effect and I am removing it. 